### PR TITLE
Handle 302 redirect

### DIFF
--- a/lib/koala/http_services.rb
+++ b/lib/koala/http_services.rb
@@ -81,6 +81,10 @@ module Koala
             else
               http.get("#{path}?#{encode_params(args)}")
             end
+            # hijack the location header for 302 requests
+            # http://developers.facebook.com/docs/reference/api/album/
+            # album connection to picture is a 302
+            body = {:data => [{ :thumb => response["location"] }]}.to_json if response.code.to_i == 302
             
             Koala::Response.new(response.code.to_i, body, response)
           end


### PR DESCRIPTION
Whipped this up real quick (really quick) to handle getting the picture connection for an album (http://developers.facebook.com/docs/reference/api/album/), instead of returning data, it returns status 302 with the header location value set to the image URL.
