### PR TITLE
Patch for Issue #65: Return [] if empty array passed to get_objects.

### DIFF
--- a/lib/koala/graph_api.rb
+++ b/lib/koala/graph_api.rb
@@ -40,6 +40,7 @@ module Koala
         # Fetchs all of the given object from the graph.
         # We return a map from ID to object. If any of the IDs are invalid,
         # we raise an exception.
+        return [] if ids.empty?
         graph_call("", args.merge("ids" => ids.join(",")), "get", options)
       end
       

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -51,9 +51,14 @@ shared_examples_for "Koala GraphAPI" do
     (result["id"] && result["name"]).should
   end
 
+  it "should return [] from get_objects if passed an empty array" do
+    results = @api.get_objects([])
+    results.should == []
+  end
+  
   it "should be able to get multiple objects" do
     results = @api.get_objects(["contextoptional", "naitik"])
-    results.length.should == 2
+    results.should have(2).items
   end
 
   it "should be able to access a user's picture" do


### PR DESCRIPTION
Issue #65: Return an empty array if an empty array is passed to KoalaGraphAPI#get_objects.
