### PR TITLE
provided option to set default values for proxy and timeout

### DIFF
--- a/lib/koala/http_services.rb
+++ b/lib/koala/http_services.rb
@@ -13,7 +13,7 @@ module Koala
     def self.included(base)
       base.class_eval do
         class << self
-          attr_accessor :always_use_ssl
+          attr_accessor :always_use_ssl, :proxy, :timeout
         end
                
         def self.server(options = {})
@@ -50,7 +50,11 @@ module Koala
           # by default, we use SSL only for private requests
           # this makes public requests faster
           private_request = args["access_token"] || @always_use_ssl || options[:use_ssl]
-
+          
+          # if proxy/timeout options aren't passed, check if defaults are set
+          options[:proxy] ||= proxy
+          options[:timeout] ||= timeout
+          
           # if the verb isn't get or post, send it as a post argument
           args.merge!({:method => verb}) && verb = "post" if verb != "get" && verb != "post"
 

--- a/spec/cases/http_services/http_service_spec.rb
+++ b/spec/cases/http_services/http_service_spec.rb
@@ -17,6 +17,24 @@ describe "Koala::HTTPService" do
       end
     end
     
+    describe "proxy accessor" do
+      it "should be added" do
+        # in Ruby 1.8, .methods returns strings
+        # in Ruby 1.9, .method returns symbols 
+        Bear.methods.collect {|m| m.to_sym}.should include(:proxy)
+        Bear.methods.collect {|m| m.to_sym}.should include(:proxy=)
+      end
+    end
+    
+    describe "timeout accessor" do
+      it "should be added" do
+        # in Ruby 1.8, .methods returns strings
+        # in Ruby 1.9, .method returns symbols 
+        Bear.methods.collect {|m| m.to_sym}.should include(:timeout)
+        Bear.methods.collect {|m| m.to_sym}.should include(:timeout=)
+      end
+    end
+    
     describe "server" do
       describe "without options[:beta]" do
         it "should return the rest server if options[:rest_api]" do

--- a/spec/cases/http_services/net_http_service_spec.rb
+++ b/spec/cases/http_services/net_http_service_spec.rb
@@ -128,6 +128,60 @@ describe "NetHTTPService module holder class Horse" do
         Horse.make_request('anything', {}, 'anything')
       end
     end
+    
+    describe "proxy options" do
+      before :each do
+        Horse.proxy = "http://defaultproxy"
+      end
+      after :all do
+        Horse.proxy = nil
+      end
+
+      it "should use passed proxy option if provided" do
+        Net::HTTP.should_receive(:new).with(Koala::Facebook::GRAPH_SERVER, anything, "passedproxy", 80, nil, nil).and_return(@http_mock)
+        Horse.make_request('anything', {} , 'anything', {:proxy => "http://passedproxy"})
+      end
+      
+      it "should use default proxy if default is provided and NO proxy option passed" do
+        Net::HTTP.should_receive(:new).with(Koala::Facebook::GRAPH_SERVER, anything, "defaultproxy", 80, nil, nil).and_return(@http_mock)
+        Horse.make_request('anything', {} , 'anything', {})
+      end
+      
+      it "should NOT use a proxy if default is NOT provided and NO proxy option passed" do
+        Horse.proxy = nil
+        Net::HTTP.should_receive(:new).with(Koala::Facebook::GRAPH_SERVER, anything).and_return(@http_mock)
+        Horse.make_request('anything', {} , 'anything', {})
+      end
+    end
+    
+    describe "timeout options" do
+      before :each do
+        Horse.timeout = 20 # seconds
+      end
+      after :all do
+        Horse.timeout = nil # seconds
+      end
+
+      it "should use passed timeout option if provided" do
+        @http_mock.should_receive('open_timeout=').with(10)
+        @http_mock.should_receive('read_timeout=').with(10)
+        Horse.make_request('anything', {} , 'anything', {:timeout => 10})
+      end
+      
+      it "should use default timout if default is provided and NO timeout option passed" do
+        @http_mock.should_receive('open_timeout=').with(20)
+        @http_mock.should_receive('read_timeout=').with(20)
+        Horse.make_request('anything', {} , 'anything', {})
+      end
+      
+      it "should NOT use a timeout if default is NOT provided and NO timeout option passed" do
+        Horse.timeout = nil # seconds
+        @http_mock.should_not_receive('open_timeout=')
+        @http_mock.should_not_receive('read_timeout=')
+        Horse.make_request('anything', {} , 'anything', {})
+      end
+    end
+    
 
     it "should use the graph server by default" do
       Net::HTTP.should_receive(:new).with(Koala::Facebook::GRAPH_SERVER, anything).and_return(@http_mock)


### PR DESCRIPTION
Thanks for providing this awesome gem.  I wanted to be able to set the proxy and timeout values when Rails started, so I added this functionality following conventions seen for always_use_ssl.  Specs are also provided.
-- many thanks to markmcspadden 

Rails config file now looks like:

Koala.timeout = 5 # seconds

if Rails.env.development?
  Koala.proxy = "http://127.0.0.1:8080"  # or use ENV["http_proxy"]
  FB_APP_ID = 'app_id'
  FB_APP_SECRET = 'app_secret'
elsif Rails.env.production?
  FB_APP_ID = 'app_id'
  FB_APP_SECRET = 'app_secret'7'
end 
