### PR TITLE
Enables default options for Koala APIs.

### DIFF
--- a/lib/koala.rb
+++ b/lib/koala.rb
@@ -31,7 +31,8 @@ module Koala
 
     class API
       # initialize with an access token
-      def initialize(access_token = nil)
+      def initialize(access_token = nil, default_options = {})
+        @default_options = default_options
         @access_token = access_token
       end
       attr_reader :access_token
@@ -39,6 +40,7 @@ module Koala
       def api(path, args = {}, verb = "get", options = {}, &error_checking_block)
         # Fetches the given path in the Graph API.
         args["access_token"] = @access_token || @app_access_token if @access_token || @app_access_token
+        options = @default_options.merge(options) # options takes precedence
         
         # add a leading /
         path = "/#{path}" unless path =~ /^\//


### PR DESCRIPTION
set default options (such as :ca_path) once.

See
- http://programming.nitinpande.com/2011/05/facebook-koala-plugin-open-ssl-issue.html,
- https://github.com/arsduo/koala/issues/69
  for the discussion/explanation.
