### PR TITLE
Added get_page_access_token convenience method

### DIFF
--- a/lib/koala/graph_api.rb
+++ b/lib/koala/graph_api.rb
@@ -192,7 +192,12 @@ module Koala
           result ? GraphCollection.new(result, self) : nil # when facebook is down nil can be returned
         end
       end
-      
+     
+      # Page Access Token Support
+      def get_page_access_token(object_id)
+        result = get_object(object_id, :fields => "access_token")
+        result ? result["access_token"] : nil
+      end
       
       # Batch API
       def batch(http_options = {}, &block)

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -407,3 +407,9 @@ graph_api:
   /777777777:
     no_args:
       <<: *item_deleted
+
+  /my_page:
+    fields=access_token:
+      get:
+        <<: *token_required
+        with_token: '{"access_token": "<%= APP_ACCESS_TOKEN %>"}'

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -290,6 +290,11 @@ shared_examples_for "Koala GraphAPI with an access token" do
     like_result.should be_true
   end
 
+  # Page Access Token Support
+  it "should be able to get a page's access token" do
+    result = @api.get_page_access_token("my_page")
+    result.should == Koala::MockHTTPService::OAUTH_DATA["app_access_token"]
+  end
 
   # test all methods to make sure they pass data through to the API
   # we run the tests here (rather than in the common shared example group)


### PR DESCRIPTION
Hey,

I added a convenience method to get a page access token using the new method described by Facebook here: http://developers.facebook.com/blog/post/524/

It simply goes like:

page_access_token = graph.get_page_access_token("mypage")

Let me know if I need to tweak things up
Marc -
