### PR TITLE
Added convenience method to upload photos via the GraphAPI using a URL

### DIFF
--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -133,26 +133,27 @@ graph_api:
     fields=id:
       get: 
         with_token: '{"id": "216743"}'
-        
+
   /me/feed:
     message=Hello, world, from the test suite!: 
-      post: 
+      post:
         with_token: '{"id": "MOCK_FEED_ITEM"}'
     message=Hello, world, from the test suite, testing comments!:
       post:
         with_token: '{"id": "MOCK_FEED_ITEM"}'
     message=the cats are asleep: 
-      post: 
+      post:
         with_token: '{"id": "FEED_ITEM_CATS"}'
     message=Hello, world, from the test suite delete method!: 
-      post: 
+      post:
         with_token: '{"id": "FEED_ITEM_DELETE"}'
     message=Hello, world, from the test suite batch API!: 
-      post: 
+      post:
         with_token: '{"id": "FEED_ITEM_BATCH"}'
     link=http://oauth.twoalex.com/&message=Hello, world, from the test suite again!&name=OAuth Playground:
       post:
         with_token: '{"id": "FEED_ITEM_CONTEXT"}'
+
   /me/photos:
     source=[FILE]:
       post:
@@ -162,6 +163,21 @@ graph_api:
       post:
         <<: *token_required
         with_token: '{"id": "MOCK_PHOTO"}'
+    url=http://somesite.com/cute_cat.jpg:
+      post:
+        <<: *token_required
+        with_token: '{"id": "MOCK_PHOTO_FROM_URL"}'
+    message=my message&url=http://somesite.com/cute_cat.jpg:
+      post:
+        <<: *token_required
+        with_token: '{"id": "MOCK_PHOTO_FROM_URL"}'
+
+  /theharvard/photos:
+    message=another message&url=http://somesite.com/cute_cat.jpg:
+      post:
+        <<: *token_required
+        with_token: '{"id": "MOCK_PHOTO_FROM_URL"}'
+
   /me/videos:
     source=[FILE]:
       post:

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -206,8 +206,30 @@ shared_examples_for "Koala GraphAPI with an access token" do
       get_result = @api.get_object(@temporary_object_id)
       get_result["name"].should == expected_message
     end
+
+    describe "using a URL instead of a file" do
+      before(:all) do
+        @image_url = "http://somesite.com/cute_cat.jpg"
+      end
+
+      it "should be able to post photo to the user's wall using a URL" do
+        result = @api.put_picture(@image_url)
+        result["id"].should == "MOCK_PHOTO_FROM_URL"
+      end
+
+      it "should be able to post photo to the user's wall using a URL and an additional param" do
+        result = @api.put_picture(@image_url, :message => "my message")
+        result["id"].should == "MOCK_PHOTO_FROM_URL"
+      end
+
+      it "should be able to post photo to the user's wall using a URL and a target_id" do
+        result = @api.put_picture(@image_url, {:message => "another message"}, "theharvard")
+        result["id"].should == "MOCK_PHOTO_FROM_URL"
+      end
+    end
+
   end
-  
+
   describe ".put_video" do
     before :each do
       @cat_movie = File.join(File.dirname(__FILE__), "..", "fixtures", "cat.m4v")      


### PR DESCRIPTION
Hi,

I updated the put_image method to fit the latest blog post allowing us to upload images using a URL: http://developers.facebook.com/blog/post/526/

The idea is to be able to call the method as such:

`put_picture(picture_url, {:message => "Message"}, my_page_id)
put_picture(picture_url, {}, my_page_id)
put_picture(picture_url) # defaults to me`

I followed the arguments structure used before to be able to use the same method since I think it's better than using something like put_picture_from_url.

The only thing is that I lost some minor performances in the process, meaning that I have to check if the first parameter of put_picture is a URL or not. I think that being able to go ...

`put_picture(file_path, ...)
put_picture(file, ...)
put_picture(picture_url, ...)`

... is pretty cool so it's worth it (there won't be any huge perf lost). 
But let me know what you think, I'd be ok to rework that a bit if needed!

(Also I removed some trailing whitespaces since they annoyed me ^^
Maybe I could do a different commit removing all trailing whitespaces from Koala.)
