### PR TITLE
bug in parse_signed_request

### DIFF
--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -104,7 +104,7 @@ module Koala
         raise "SignedRequest: Unsupported algorithm #{envelope['algorithm']}" if envelope['algorithm'] != 'HMAC-SHA256'
 
         # now see if the signature is valid (digest, key, data)
-        hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, @app_secret, encoded_envelope.tr("-_", "+/"))
+        hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, @app_secret, encoded_envelope)
         raise 'SignedRequest: Invalid signature' if (signature != hmac)
 
         return envelope


### PR DESCRIPTION
Greetings arsdu (and company),
  Thanks for the awesome Koala gem! I recently discovered a bug in the parse_signed_request method in the OAuth class. I was getting a lot of Invalid Signature exceptions during Facebook posts, which should have been valid. I specifically encountered this issue while using the Credits API. It appears that Facebook is including _ and - characters in the encoded_envelope data. Although we need to replace these characters in the string before we decode the data, this transformation causes problems when it is run on the 'encoded_envelope' before the digest occurs. When I remove this string transformation on the encoded_envelope data involved in the digest, parse_signed_request rightfully authenticates the Facebook request. I can verify the fix with my own application data but writing a spec is difficult (being that these encoded data callbacks are difficult to contrive). Thanks for reading this.

-- Will
