### PR TITLE
Pull request for compatibility with Ads API

### DIFF
--- a/lib/koala/graph_collection.rb
+++ b/lib/koala/graph_collection.rb
@@ -14,7 +14,11 @@ module Koala
       attr_reader :api
 
       def initialize(response, api)
-        super response["data"]
+        if response["data"].instance_of? Hash
+          super [response["data"]]
+        else
+          super response["data"]
+        end
         @paging = response["paging"]
         @api = api
       end


### PR DESCRIPTION
response['data'] is returned as an Hash when querying the ads api, I have addd a line of code to wrap the hash in an array.
