### PR TITLE
Don't query FB when using oauth. get_user_from_cookie

### DIFF
--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -48,9 +48,12 @@ module Koala
       #
       # @return the authenticated user's Facebook ID, or nil.
       def get_user_from_cookie(cookies)
-        if info = get_user_info_from_cookies(cookies)
-          # signed cookie has user_id, unsigned cookie has uid
-          string = info["user_id"] || info["uid"]
+        if signed_cookie = cookies["fbsr_#{@app_id}"]
+          components = parse_signed_request(signed_cookie)
+          string = components["user_id"] if components
+        elsif info = get_user_info_from_cookies(cookies)
+          # Parsing unsigned cookie
+          string = info["uid"]
         end
       end
       alias_method :get_user_from_cookies, :get_user_from_cookie

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -166,12 +166,12 @@ describe "Koala::Facebook::OAuth" do
           @oauth.stub(:get_access_token_info).and_return("access_token" => "my token")          
         end
 
-        it "uses get_user_info_from_cookies to parse the cookies" do
-          @oauth.should_receive(:get_user_info_from_cookies).with(@cookie).and_return({})
+        it "not uses get_user_info_from_cookies to parse the cookies" do
+          @oauth.should_not_receive(:get_user_info_from_cookies).with(@cookie).and_return({})
           @oauth.get_user_from_cookies(@cookie)
         end
 
-        it "uses return the token string if the cookies are valid" do
+        it "uses return the facebook user id string if the cookies are valid" do
           result = @oauth.get_user_from_cookies(@cookie)
           result.should == "2905623" # the user who generated the original test cookie
         end


### PR DESCRIPTION
Hello!

Thanks for your great gem! I found it very usefull!

Digging into the code I found that oauth.get_user_from_cookie uses oauth.get_user_info_from_cookies method (which queries FB for getting tha access token) for obtaining the facebook user id. The fb user id can be obtained without the access token retrieval query, I pull you the code.

Thanks!
Sergio Espeja
