### PR TITLE
Sorting the parameters makes it easier to test URLs produced by HTTPService#encode

### DIFF
--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -86,7 +86,7 @@ module Koala
     #
     # @return the appropriately-encoded string
     def self.encode_params(param_hash)
-      ((param_hash || {}).collect do |key_and_value|
+      ((param_hash || {}).sort_by{|k, v| k.to_s}.collect do |key_and_value|
         key_and_value[1] = MultiJson.encode(key_and_value[1]) unless key_and_value[1].is_a? String
         "#{key_and_value[0].to_s}=#{CGI.escape key_and_value[1]}"
       end).join("&")

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -123,6 +123,13 @@ describe "Koala::HTTPService" do
         val.should == CGI.escape(args[key])
       end
     end
+    
+    it "encodes parameters in alphabetical order" do
+      args = {:b => '2', 'a' => '1'}
+      
+      result = Koala::HTTPService.encode_params(args)
+      result.split('&').map{|key_val| key_val.split('=')[0]}.should == ['a', 'b']
+    end
 
     it "converts all keys to Strings" do
       args = Hash[*(1..4).map {|i| [i, "val#{i}"]}.flatten]


### PR DESCRIPTION
Now sorting the parameter hash by key.to_s before encoding the values. Minor change but helps with testing from client code.
