### PR TITLE
Minor optimisation to the way that RealtimeUpdates.meet_challenge works

### DIFF
--- a/lib/koala/realtime_updates.rb
+++ b/lib/koala/realtime_updates.rb
@@ -101,11 +101,11 @@ module Koala
             # you can make sure this is legitimate through two ways
             # if your store the token across the calls, you can pass in the token value
             # and we'll make sure it matches
-            (verify_token && params["hub.verify_token"] == verify_token) ||
+            ((verify_token && params["hub.verify_token"] == verify_token) ||
             # alternately, if you sent a specially-constructed value (such as a hash of various secret values)
             # you can pass in a block, which we'll call with the verify_token sent by Facebook
             # if it's legit, return anything that evaluates to true; otherwise, return nil or false
-            (verification_block && yield(params["hub.verify_token"]))
+            (verification_block && yield(params["hub.verify_token"])))
           params["hub.challenge"]
         else
           false

--- a/spec/cases/realtime_updates_spec.rb
+++ b/spec/cases/realtime_updates_spec.rb
@@ -243,6 +243,13 @@ describe "Koala::Facebook::RealtimeUpdates" do
       params = {'hub.mode' => 'not subscribe'}
       Koala::Facebook::RealtimeUpdates.meet_challenge(params).should be_false
     end
+
+    it "doesn't evaluate the block if hub.mode isn't subscribe" do
+      params = {'hub.mode' => 'not subscribe'}
+      block_evaluated = false
+      Koala::Facebook::RealtimeUpdates.meet_challenge(params){|token| block_evaluated = true}
+      block_evaluated.should be_false
+    end
     
     it "returns false if not given a verify_token or block" do
       params = {'hub.mode' => 'subscribe'}


### PR DESCRIPTION
Currently in RealtimeUpdate#meet_challenge, you can pass in a block to check that the token from facebook is valid. This is always evaluated, even if other parts of the challenge (ie. the mode) are invalid (and therefore meet_challenge is always going to return false regardless of what's returned from the block)

In my case, inside the challenge block I load models from the database, and I wouldn't want this to happen if the meet_challenge is always going to return false.

I've added a test for this and fixed the "bug" (ie. added extra brackets to correct the binding).
