### PR TITLE
Improved pagination url parsing

### DIFF
--- a/lib/koala/api/graph_collection.rb
+++ b/lib/koala/api/graph_collection.rb
@@ -87,10 +87,11 @@ module Koala
         #
         # @return an array of parameters that can be provided via graph_call(*parsed_params)
         def self.parse_page_url(url)
-          match = url.match(/.com\/(.*)\?(.*)/)
-          base = match[1]
-          args = match[2]
-          params = CGI.parse(args)
+          uri = URI.parse(url)
+
+          base = uri.path.sub(/^\//, '')
+          params = CGI.parse(uri.query)
+
           new_params = {}
           params.each_pair do |key,value|
             new_params[key] = value.join ","

--- a/spec/cases/graph_collection_spec.rb
+++ b/spec/cases/graph_collection_spec.rb
@@ -91,12 +91,12 @@ describe Koala::Facebook::GraphCollection do
     describe ".parse_page_url" do    
       it "should return the base as the first array entry" do
         base = "url_path"
-        Koala::Facebook::GraphCollection.parse_page_url("anything.com/#{base}?anything").first.should == base
+        Koala::Facebook::GraphCollection.parse_page_url("http://anything.net/#{base}?anything").first.should == base
       end
 
       it "should return the arguments as a hash as the last array entry" do
         args_hash = {"one" => "val_one", "two" => "val_two"}
-        Koala::Facebook::GraphCollection.parse_page_url("anything.com/anything?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}").last.should == args_hash
+        Koala::Facebook::GraphCollection.parse_page_url("http://anything.net/anything?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}").last.should == args_hash
       end
     end
   end


### PR DESCRIPTION
We improved the URL parsing by switching to the URI library.

We needed this for a performance test we're building that hits a mock Facebook endpoint. We needed to be able to support hostnames other than *.com (e.g., other TLDs, a plain IP address, etc).
