### PR TITLE
Always verify SSL certificate (verify peer)

### DIFF
--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -66,6 +66,7 @@ module Koala
       # figure out our options for this request
       request_options = {:params => (verb == "get" ? params : {})}.merge(http_options || {}).merge(process_options(options))
       request_options[:use_ssl] = true if args["access_token"] # require https if there's a token
+      (request_options[:ssl] ||= {})[:verify] = true if request_options[:use_ssl]
 
       # set up our Faraday connection
       # we have to manually assign params to the URL or the

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -188,7 +188,7 @@ describe "Koala::HTTPService" do
       it "forces use_ssl to true if an access token is present" do
         options = {:use_ssl => false}
         Koala::HTTPService.stub(:http_options).and_return(:use_ssl => false)
-        Faraday.should_receive(:new).with(anything, hash_including(:use_ssl => true)).and_return(@mock_connection)
+        Faraday.should_receive(:new).with(anything, hash_including(:use_ssl => true, :ssl => {:verify => true})).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {"access_token" => "foo"}, "get", options)
       end
 


### PR DESCRIPTION
Using SSL without verifying the certificate is quite pointless. Moreover, as koala is not a generic HTTP client, which needs to deal with invalid certificates from time to time, it's better to verify the certificate.

The faraday adapter will check if there's :ssl key, and if :verify is not set to false, it will then configure it with the  default store.
https://github.com/technoweenie/faraday/blob/master/lib/faraday/adapter/net_http.rb
