### PR TITLE
Relax multi_json restriction

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["readme.md", "CHANGELOG"]
   gem.rdoc_options     = ["--line-numbers", "--inline-source", "--title", "Koala"]
 
-  gem.add_runtime_dependency(%q<multi_json>,    ["~> 1.2"])
+  gem.add_runtime_dependency(%q<multi_json>,    ["~> 1.3"])
   gem.add_runtime_dependency(%q<faraday>,       ["~> 0.7.0"])
   gem.add_development_dependency(%q<rspec>,     ["~> 2.8.0rc1"])
   gem.add_development_dependency(%q<rake>,      ["~> 0.8"])

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -57,8 +57,8 @@ module Koala
 
         # parse the body as JSON and run it through the error checker (if provided)
         # Note: Facebook sometimes sends results like "true" and "false", which aren't strictly objects
-        # and cause MultiJson.decode to fail -- so we account for that by wrapping the result in []
-        body = MultiJson.decode("[#{result.body.to_s}]")[0]
+        # and cause MultiJson.load to fail -- so we account for that by wrapping the result in []
+        body = MultiJson.load("[#{result.body.to_s}]")[0]
         yield body if error_checking_block
 
         # if we want a component other than the body (e.g. redirect header for images), return that

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -318,7 +318,7 @@ module Koala
       #
       # @return a hash of FQL results keyed to the appropriate query
       def fql_multiquery(queries = {}, args = {}, options = {})
-        if results = get_object("fql", args.merge(:q => MultiJson.encode(queries)), options)
+        if results = get_object("fql", args.merge(:q => MultiJson.dump(queries)), options)
           # simplify the multiquery result format
           results.inject({}) {|outcome, data| outcome[data["name"]] = data["fql_result_set"]; outcome}
         end
@@ -353,7 +353,7 @@ module Koala
       end
 
       def set_app_restrictions(app_id, restrictions_hash, args = {}, options = {})
-        graph_call(app_id, args.merge(:restrictions => MultiJson.encode(restrictions_hash)), "post", options)
+        graph_call(app_id, args.merge(:restrictions => MultiJson.dump(restrictions_hash)), "post", options)
       end
 
       # Certain calls such as {#get_connections} return an array of results which you can page through

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -41,7 +41,7 @@ module Koala
       end
 
       # redefine the graph_call and check_response methods
-      # so we can use this API inside the batch block just like any regular Graph API  
+      # so we can use this API inside the batch block just like any regular Graph API
       alias_method :graph_call_outside_batch, :graph_call
       alias_method :graph_call, :graph_call_in_batch
 
@@ -53,7 +53,7 @@ module Koala
         return [] unless batch_calls.length > 0
         # Turn the call args collected into what facebook expects
         args = {}
-        args["batch"] = MultiJson.encode(batch_calls.map { |batch_op|
+        args["batch"] = MultiJson.dump(batch_calls.map { |batch_op|
           args.merge!(batch_op.files) if batch_op.files
           batch_op.to_batch_params(access_token)
         })
@@ -68,7 +68,7 @@ module Koala
 
             if call_result
               # (see note in regular api method about JSON parsing)
-              body = MultiJson.decode("[#{call_result['body'].to_s}]")[0]
+              body = MultiJson.load("[#{call_result['body'].to_s}]")[0]
 
               unless call_result["code"].to_i >= 500 || error = check_response(body)
                 # Get the HTTP component they want
@@ -92,7 +92,7 @@ module Koala
             end
           end
         end
-        
+
         # turn any results that are pageable into GraphCollections
         batch_result.inject([]) {|processed_results, raw| processed_results << GraphCollection.evaluate(raw, @original_api)}
       end

--- a/lib/koala/api/rest_api.rb
+++ b/lib/koala/api/rest_api.rb
@@ -2,19 +2,19 @@ module Koala
   module Facebook
     REST_SERVER = "api.facebook.com"
 
-    # Methods used to interact with Facebook's legacy REST API.  
+    # Methods used to interact with Facebook's legacy REST API.
     # Where possible, you should use the newer, faster Graph API to interact with Facebook;
     # in the future, the REST API will be deprecated.
     # For now, though, there are a few methods that can't be done through the Graph API.
     #
-    # When using the REST API, Koala will use Facebook's faster read-only servers 
-    # whenever the call allows.  
+    # When using the REST API, Koala will use Facebook's faster read-only servers
+    # whenever the call allows.
     #
     # See https://github.com/arsduo/koala/wiki/REST-API for a general introduction to Koala
     # and the Rest API.
     module RestAPIMethods
       # Set a Facebook application's properties.
-      # 
+      #
       # @param properties a hash of properties you want to update with their new values.
       # @param (see #rest_call)
       # @param options (see #rest_call)
@@ -22,20 +22,20 @@ module Koala
       # @return true if successful, false if not.  (This call currently doesn't give useful feedback on failure.)
       def set_app_properties(properties, args = {}, options = {})
         raise APIError.new({"type" => "KoalaMissingAccessToken", "message" => "setAppProperties requires an access token"}) unless @access_token
-        rest_call("admin.setAppProperties", args.merge(:properties => MultiJson.encode(properties)), options, "post")
+        rest_call("admin.setAppProperties", args.merge(:properties => MultiJson.dump(properties)), options, "post")
       end
 
-      # Make a call to the REST API. 
+      # Make a call to the REST API.
       #
       # @note The order of the last two arguments is non-standard (for historical reasons).  Sorry.
-      # 
+      #
       # @param fb_method the API call you want to make
       # @param args (see Koala::Facebook::GraphAPIMethods#graph_call)
       # @param options (see Koala::Facebook::GraphAPIMethods#graph_call)
       # @param verb (see Koala::Facebook::GraphAPIMethods#graph_call)
-      # 
+      #
       # @raise [Koala::Facebook::APIError] if Facebook returns an error
-      # 
+      #
       # @return the result from Facebook
       def rest_call(fb_method, args = {}, options = {}, verb = "get")
         Koala::Utils.deprecate("The REST API is now deprecated; please use the equivalent Graph API methods instead.  See http://developers.facebook.com/blog/post/616/.")

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -90,7 +90,7 @@ module Koala
     # @return the appropriately-encoded string
     def self.encode_params(param_hash)
       ((param_hash || {}).sort_by{|k, v| k.to_s}.collect do |key_and_value|
-        key_and_value[1] = MultiJson.encode(key_and_value[1]) unless key_and_value[1].is_a? String
+        key_and_value[1] = MultiJson.dump(key_and_value[1]) unless key_and_value[1].is_a? String
         "#{key_and_value[0].to_s}=#{CGI.escape key_and_value[1]}"
       end).join("&")
     end

--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -229,7 +229,7 @@ module Koala
         raise 'SignedRequest: Invalid (incomplete) signature data' unless encoded_sig && encoded_envelope
 
         signature = base64_url_decode(encoded_sig).unpack("H*").first
-        envelope = MultiJson.decode(base64_url_decode(encoded_envelope))
+        envelope = MultiJson.load(base64_url_decode(encoded_envelope))
 
         raise "SignedRequest: Unsupported algorithm #{envelope['algorithm']}" if envelope['algorithm'] != 'HMAC-SHA256'
 
@@ -260,7 +260,7 @@ module Koala
           })
         end
 
-        MultiJson.decode(response)
+        MultiJson.load(response)
       end
 
       # @deprecated (see #get_token_info_from_session_keys)
@@ -285,7 +285,7 @@ module Koala
         result = fetch_token_string(args, post, "access_token", options)
 
         # if we have an error, parse the error JSON and raise an error
-        raise APIError.new((MultiJson.decode(result)["error"] rescue nil) || {}) if result =~ /error/
+        raise APIError.new((MultiJson.load(result)["error"] rescue nil) || {}) if result =~ /error/
 
         # otherwise, parse the access token
         parse_access_token(result)

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -50,7 +50,7 @@ describe "Koala::Facebook::API" do
   it "returns the entire response if http_component => :response" do
     http_component = :response
     response = mock('Mock KoalaResponse', :body => '', :status => 200)
-    Koala.stub(:make_request).and_return(response)    
+    Koala.stub(:make_request).and_return(response)
     @service.api('anything', {}, 'get', :http_component => http_component).should == response
   end
 
@@ -59,7 +59,7 @@ describe "Koala::Facebook::API" do
     Koala.stub(:make_request).and_return(response)
 
     json_body = mock('JSON body')
-    MultiJson.stub(:decode).and_return([json_body])
+    MultiJson.stub(:load).and_return([json_body])
 
     @service.api('anything').should == json_body
   end
@@ -73,7 +73,7 @@ describe "Koala::Facebook::API" do
 
     @service.api('anything', {}, "get") do |arg|
       yield_test.pass
-      arg.should == MultiJson.decode(body)
+      arg.should == MultiJson.load(body)
     end
   end
 

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -304,7 +304,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           Koala::Facebook::GraphBatchAPI::BatchOperation.stub(:new).and_return(op)
 
           # two requests should generate two batch operations
-          expected = MultiJson.encode([op.to_batch_params(access_token), op.to_batch_params(access_token)])
+          expected = MultiJson.dump([op.to_batch_params(access_token), op.to_batch_params(access_token)])
           Koala.should_receive(:make_request).with(anything, hash_including("batch" => expected), anything, anything).and_return(@fake_response)
           Koala::Facebook::API.new(access_token).batch do |batch_api|
             batch_api.get_object('me')

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -99,7 +99,7 @@ describe "Koala::HTTPService" do
       val = 'json_value'
       not_a_string = 'not_a_string'
       not_a_string.stub(:is_a?).and_return(false)
-      MultiJson.should_receive(:encode).with(not_a_string).and_return(val)
+      MultiJson.should_receive(:dump).with(not_a_string).and_return(val)
 
       string = "hi"
 

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -661,7 +661,7 @@ describe "Koala::Facebook::OAuth" do
     # the signed request code is ported directly from Facebook
     # so we only need to test at a high level that it works
     it "throws an error if the algorithm is unsupported" do
-      MultiJson.stub(:decode).and_return("algorithm" => "my fun algorithm")
+      MultiJson.stub(:load).and_return("algorithm" => "my fun algorithm")
       lambda { @oauth.parse_signed_request(@signed_request) }.should raise_error
     end
 

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -68,53 +68,53 @@ graph_api:
         no_token: '{"contextoptional":"{}","koppel":"{}"}'
 
     # Ruby 1.8.7 and 1.9.2 generate JSON with different key ordering, hence we have to dynamically generate it here
-    batch=<%= MultiJson.encode([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "koppel"}]) %>:
+    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "koppel"}]) %>:
       post:
         with_token: '[{"body":"{\"id\":\"123\"}"}, {"body":"{\"id\":\"456\"}"}]'
-    batch=<%= MultiJson.encode([{"method" => "get", "relative_url" => "me/picture"}]) %>:
+    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/picture"}]) %>:
       post:
         with_token: '[{"headers":[{"name":"Location","value":"http://google.com"}]}]'
-    batch=<%= MultiJson.encode([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "me/friends"}]) %>:
+    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "me/friends"}]) %>:
       post:
         with_token: '[{"body":"{\"id\":\"123\"}"}, {"body":"{\"data\":[],\"paging\":{}}"}]'
-    batch=<%= MultiJson.encode([{"method"=>"get", "relative_url"=>"me"}, {"method"=>"get", "relative_url"=>"#{OAUTH_DATA["app_id"]}/insights?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
+    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"me"}, {"method"=>"get", "relative_url"=>"#{OAUTH_DATA["app_id"]}/insights?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
       post:
         with_token: '[{"body":"{\"id\":\"123\"}"}, {"body":"{\"data\":[],\"paging\":{}}"}]'
-    batch=<%= MultiJson.encode([{"method"=>"get", "relative_url"=>"2/invalidconnection"}, {"method"=>"get", "relative_url"=>"koppel?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
+    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"2/invalidconnection"}, {"method"=>"get", "relative_url"=>"koppel?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
       post:
         with_token: '[{"body": "{\"error\":{\"type\":\"AnError\", \"message\":\"An error occurred!.\"}}"},{"body":"{\"id\":\"123\"}"}]'
-    batch=<%= MultiJson.encode([{"method"=>"post", "relative_url"=>"FEED_ITEM_BATCH/likes"}, {"method"=>"delete", "relative_url"=> "FEED_ITEM_BATCH"}]) %>:
+    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"FEED_ITEM_BATCH/likes"}, {"method"=>"delete", "relative_url"=> "FEED_ITEM_BATCH"}]) %>:
       post:
         with_token: '[{"body": "{\"id\": \"MOCK_LIKE\"}"},{"body":true}]'
-    batch=<%= MultiJson.encode([{"method" => "post", "relative_url" => "method/fql.query", "body" => "query=select+first_name+from+user+where+uid%3D2905623"}]) %>:
+    batch=<%= MultiJson.dump([{"method" => "post", "relative_url" => "method/fql.query", "body" => "query=select+first_name+from+user+where+uid%3D2905623"}]) %>:
       post:
         with_token: '[{"body":"[{\"first_name\":\"Alex\"}]"}]'
 
     # dependencies
-    batch=<%= MultiJson.encode([{"method"=>"get", "relative_url"=>"me", "name" => "getme"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getme"}]) %>:
+    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"me", "name" => "getme"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getme"}]) %>:
       post:
         with_token: '[null,{"body":"{\"id\":\"123\"}"}]'
-    batch=<%= MultiJson.encode([{"method"=>"get", "relative_url"=>"2/invalidconnection", "name" => "getdata"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getdata"}]) %>:
+    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"2/invalidconnection", "name" => "getdata"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getdata"}]) %>:
       post:
         with_token: '[{"body": "{\"error\":{\"type\":\"AnError\", \"message\":\"An error occurred!.\"}}"},null]'
-    batch=<%= MultiJson.encode([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
+    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
       post:
         with_token: '[null,{"body":"{}"}]'
-    batch=<%= MultiJson.encode([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends", "omit_response_on_success" => false}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
+    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends", "omit_response_on_success" => false}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
       post:
         with_token: '[{"body":"{\"data\":[],\"paging\":{}}"},{"body":"{}"}]'
-    batch=<%= MultiJson.encode([{"method" => "get", "relative_url" => "me/friends?limit=5"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=i-dont-exist:$.data.*.id}"}"}]) %>:
+    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/friends?limit=5"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=i-dont-exist:$.data.*.id}"}"}]) %>:
       post:
         with_token: '{"error":190,"error_description":"Error validating access token."}'
 
     # attached files tests
-    batch=<%= MultiJson.encode([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
+    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
       post:
         with_token: '[{"body": "{\"error\":{\"type\":\"AnError\", \"message\":\"An error occurred!.\"}}"},null]'
-    batch=<%= MultiJson.encode([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
+    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
       post:
         with_token: '[{"body":"{\"id\": \"MOCK_PHOTO\"}"}]'
-    batch=<%= MultiJson.encode([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}, {"method"=>"post", "relative_url"=>"koppel/photos", "attached_files" => "op2_file0"}]) %>&op1_file0=[FILE]&op2_file0=[FILE]:
+    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}, {"method"=>"post", "relative_url"=>"koppel/photos", "attached_files" => "op2_file0"}]) %>&op1_file0=[FILE]&op2_file0=[FILE]:
       post:
         with_token: '[{"body":"{\"id\": \"MOCK_PHOTO\"}"}, {"body":"{\"id\": \"MOCK_PHOTO\"}"}]'
 
@@ -273,11 +273,11 @@ graph_api:
       get:
         <<: *token_required
         with_token: '[{"read_stream":1}]'
-    'q=<%= MultiJson.encode({"query1" => "select post_id from stream where source_id = me()", "query2" => "select fromid from comment where post_id in (select post_id from #query1)", "query3" => "select uid, name from user where uid in (select fromid from #query2)"}) %>':
+    'q=<%= MultiJson.dump({"query1" => "select post_id from stream where source_id = me()", "query2" => "select fromid from comment where post_id in (select post_id from #query1)", "query3" => "select uid, name from user where uid in (select fromid from #query2)"}) %>':
       get:
         <<: *token_required
         with_token: '[{"name":"query1", "fql_result_set":[]},{"name":"query2", "fql_result_set":[]},{"name":"query3", "fql_result_set":[]}]'
-    'q=<%= MultiJson.encode({"query1" => "select uid, first_name from user where uid = 2901279", "query2" => "select uid, first_name from user where uid = 2905623"}) %>':
+    'q=<%= MultiJson.dump({"query1" => "select uid, first_name from user where uid = 2901279", "query2" => "select uid, first_name from user where uid = 2905623"}) %>':
       get:
         with_token: '[{"name":"query1", "fql_result_set":[{"uid":2901279,"first_name":"Luke"}]},{"name":"query2", "fql_result_set":[{"uid":"2905623","first_name":"Alex"}]}]'
         no_token: '[{"name":"query1", "fql_result_set":[{"uid":2901279,"first_name":"Luke"}]},{"name":"query2", "fql_result_set":[{"uid":"2905623","first_name":"Alex"}]}]'
@@ -296,7 +296,7 @@ graph_api:
 
 
   '/<%= APP_ID %>':
-    restrictions=<%= MultiJson.encode({"age_distr" => "13+"}) %>:
+    restrictions=<%= MultiJson.dump({"age_distr" => "13+"}) %>:
       post:
         with_token: "true"
 

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -158,7 +158,7 @@ shared_examples_for "Koala GraphAPI" do
     it "passes a queries argument" do
       queries = stub('query string')
       queries_json = "some JSON"
-      MultiJson.stub(:encode).with(queries).and_return(queries_json)
+      MultiJson.stub(:dump).with(queries).and_return(queries_json)
 
       @api.should_receive(:get_object).with(anything, hash_including(:q => queries_json), anything)
       @api.fql_multiquery(queries)
@@ -426,7 +426,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
     end
 
     it "JSON-encodes the restrictions" do
-      @app_api.should_receive(:graph_call).with(anything, hash_including(:restrictions => MultiJson.encode(@restrictions)), anything, anything)
+      @app_api.should_receive(:graph_call).with(anything, hash_including(:restrictions => MultiJson.dump(@restrictions)), anything, anything)
       @app_api.set_app_restrictions(KoalaTest.app_id, @restrictions)
     end
 

--- a/spec/support/json_testing_fix.rb
+++ b/spec/support/json_testing_fix.rb
@@ -2,7 +2,7 @@
 # which is a problem because our mock testing service ultimately matches strings to see if requests are mocked
 # this fix solves that problem by ensuring all hashes are created with a consistent key order every time
 module MultiJson
-  self.engine = :ok_json
+  self.use :ok_json
 
   class << self
     def encode_with_ordering(object)
@@ -14,16 +14,16 @@ module MultiJson
 
     alias_method :encode_original, :encode
     alias_method :encode, :encode_with_ordering
-  
+
     def decode_with_ordering(string)
       sort_object(decode_original(string))
     end
 
     alias_method :decode_original, :decode
     alias_method :decode, :decode_with_ordering
-    
-    private 
-  
+
+    private
+
     def sort_object(object)
       if object.is_a?(Hash)
         sort_hash(object)
@@ -33,7 +33,7 @@ module MultiJson
         object
       end
     end
-  
+
     def sort_hash(unsorted_hash)
       sorted_hash = KoalaTest::OrderedHash.new(sorted_hash)
       unsorted_hash.keys.sort {|a, b| a.to_s <=> b.to_s}.inject(sorted_hash) {|hash, k| hash[k] = unsorted_hash[k]; hash}

--- a/spec/support/rest_api_shared_examples.rb
+++ b/spec/support/rest_api_shared_examples.rb
@@ -126,7 +126,7 @@ shared_examples_for "Koala RestAPI with an access token" do
   describe "#set_app_properties" do
     it "sends Facebook the properties JSON-encoded as :properties" do
       props = {:a => 2, :c => [1, 2, "d"]}
-      @api.should_receive(:rest_call).with(anything, hash_including(:properties => MultiJson.encode(props)), anything, anything)
+      @api.should_receive(:rest_call).with(anything, hash_including(:properties => MultiJson.dump(props)), anything, anything)
       @api.set_app_properties(props)
     end
 
@@ -146,7 +146,7 @@ shared_examples_for "Koala RestAPI with an access token" do
       @api.should_receive(:rest_call).with(anything, anything, opts, anything)
       @api.set_app_properties({}, {}, opts)
     end
-    
+
     it "makes a POST" do
       @api.should_receive(:rest_call).with(anything, anything, anything, "post")
       @api.set_app_properties({})


### PR DESCRIPTION
The first commit is to relax the multi_json restriction as 1.3 is granted backwards compatible here: https://github.com/rails/rails/pull/5861#issuecomment-5212898

The second commits brings in specs and directly forces 1.3 onwards, the gem has been updated to reflect the new methods in MultiJson.

```
Finished in 1.6 seconds
634 examples, 0 failures, 3 pending
```
