### PR TITLE
Use faraday 0.8.0 with persistent HTTP connections

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |gem|
   gem.rdoc_options     = ["--line-numbers", "--inline-source", "--title", "Koala"]
 
   gem.add_runtime_dependency(%q<multi_json>,    ["~> 1.3.0"])
-  gem.add_runtime_dependency(%q<faraday>,       ["~> 0.7.0"])
-  gem.add_development_dependency(%q<rspec>,     ["~> 2.8.0rc1"])
+  gem.add_runtime_dependency(%q<faraday>,       ["~> 0.8.0"])
+  gem.add_runtime_dependency(%q<net-http-persistent>, ["~> 2.6"])
+  gem.add_development_dependency(%q<rspec>,     ["~> 2.9.0"])
   gem.add_development_dependency(%q<rake>,      ["~> 0.8"])
 end

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -20,7 +20,7 @@ module Koala
     DEFAULT_MIDDLEWARE = Proc.new do |builder|
       builder.use Koala::HTTPService::MultipartRequest
       builder.request :url_encoded
-      builder.adapter Faraday.default_adapter
+      builder.adapter :net_http_persistent
     end
 
     # The address of the appropriate Facebook server.

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -37,10 +37,8 @@ describe "Koala::HTTPService" do
       Koala::HTTPService::DEFAULT_MIDDLEWARE.call(@builder)
     end
 
-    it "uses the default adapter" do
-      adapter = :testing_now
-      Faraday.stub(:default_adapter).and_return(adapter)
-      @builder.should_receive(:adapter).with(adapter)
+    it "uses the net_http_persistent adapter" do
+      @builder.should_receive(:adapter).with(:net_http_persistent)
       Koala::HTTPService::DEFAULT_MIDDLEWARE.call(@builder)
     end
   end


### PR DESCRIPTION
This is what we discussed in issue #193.

I was checking it with:

sudo tcpdump -i en1 -n 'tcp[tcpflags] & (tcp-syn|tcp-fin) != 0' and port 443

and doing:

k.get_object('me'); k.get_connections('me','checkins')
