### PR TITLE
@test_users.create(true) gives me `OAuthException: (#100) invalid permissions: null`

### DIFF
--- a/lib/koala/test_users.rb
+++ b/lib/koala/test_users.rb
@@ -55,7 +55,7 @@ module Koala
       # @param options (see Koala::Facebook::API#api)
       #
       # @return a hash of information for the new user (id, access token, login URL, etc.)
-      def create(installed, permissions = nil, args = {}, options = {})
+      def create(installed, permissions = '', args = {}, options = {})
         # Creates and returns a test user
         args['installed'] = installed
         args['permissions'] = (permissions.is_a?(Array) ? permissions.join(",") : permissions) if installed


### PR DESCRIPTION
So I have to do @test_users.create(true, '') in order to create user with no additional permissions.
Please consider this microfix.
