### PR TITLE
Update Faraday's version requirement to include 0.8

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.rdoc_options     = ["--line-numbers", "--inline-source", "--title", "Koala"]
 
   gem.add_runtime_dependency(%q<multi_json>,    ["~> 1.2.0"])
-  gem.add_runtime_dependency(%q<faraday>,       ["~> 0.7.0"])
+  gem.add_runtime_dependency(%q<faraday>,       ["~> 0.7"])
   gem.add_development_dependency(%q<rspec>,     ["~> 2.8.0rc1"])
   gem.add_development_dependency(%q<rake>,      ["~> 0.8"])
 end


### PR DESCRIPTION
New Faraday version has more default middleware and other stuff. 

The only backwards-incompatible change is the signature of bodyless requests (see https://github.com/technoweenie/faraday/wiki/Changelog) in which the headers are the third arguments, with the second being additional parameters.

The only place in the code where Faraday connection is used, is https://github.com/arsduo/koala/blob/9f61c8493062ae124c39a9644bc4b28dd33182ad/lib/koala/http_service.rb#L78 where the headers param is empty. So there is no actual issue in using either 0.7 or 0.8.
