### PR TITLE
Use put_connections instead of put_object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Internal improvements:
 -- Update MultiJson dependency to support the Oj library (thanks, zinenko!)
 -- Loosened Faraday dependency (thanks, rewritten and romanbsd!)
 -- Fixed typos (thanks, nathanbertram!)
+-- Switched uses of put_object to the more semantically accurate put_connections
 -- Cleaned up gemspec
 Documentation:
 -- Added HTTP Services description for Faraday 0.8/persistent connections (thanks, romanbsd!)

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -72,8 +72,7 @@ module Koala
       #       Please use put_connections; in a future version of Koala (2.0?),
       #       put_object will issue a POST directly to an individual object, not to a connection.
       def put_object(parent_object, connection_name, args = {}, options = {})
-        raise APIError.new({"type" => "KoalaMissingAccessToken", "message" => "Write operations require an access token"}) unless @access_token
-        graph_call("#{parent_object}/#{connection_name}", args, "post", options)
+        put_connections(parent_object, connection_name, args, options)
       end
 
       # Delete an object from the Graph if you have appropriate permissions.
@@ -115,7 +114,7 @@ module Koala
       # @note (see #get_connection)
       #
       # @example
-      #         graph.put_object("me", "feed", :message => "Hello, world")
+      #         graph.put_connections("me", "feed", :message => "Hello, world")
       #         => writes "Hello, world" to the active user's wall
       #
       # Most write operations require extended permissions. For example,
@@ -192,7 +191,7 @@ module Koala
       #
       # @return (see #put_connections)
       def put_picture(*picture_args)
-        put_object(*parse_media_args(picture_args, "photos"))
+        put_connections(*parse_media_args(picture_args, "photos"))
       end
 
       # Upload a video.  Functions exactly the same as put_picture.
@@ -200,11 +199,11 @@ module Koala
       def put_video(*video_args)
         args = parse_media_args(video_args, "videos")
         args.last[:video] = true
-        put_object(*args)
+        put_connections(*args)
       end
 
       # Write directly to the user's wall.
-      # Convenience method equivalent to put_object(id, "feed").
+      # Convenience method equivalent to put_connections(id, "feed").
       #
       # To get wall posts, use get_connections(user, "feed")
       # To delete a wall post, use delete_object(post_id)
@@ -227,7 +226,7 @@ module Koala
       # @see #put_connections
       # @return (see #put_connections)
       def put_wall_post(message, attachment = {}, target_id = "me", options = {})
-        self.put_object(target_id, "feed", attachment.merge({:message => message}), options)
+        put_connections(target_id, "feed", attachment.merge({:message => message}), options)
       end
 
       # Comment on a given object.
@@ -243,7 +242,7 @@ module Koala
       # @return (see #put_connections)
       def put_comment(id, message, options = {})
         # Writes the given comment on the given post.
-        self.put_object(id, "comments", {:message => message}, options)
+        put_connections(id, "comments", {:message => message}, options)
       end
 
       # Like a given object.
@@ -257,7 +256,7 @@ module Koala
       # @return (see #put_connections)
       def put_like(id, options = {})
         # Likes the given post.
-        self.put_object(id, "likes", {}, options)
+        put_connections(id, "likes", {}, options)
       end
 
       # Unlike a given object.
@@ -447,7 +446,7 @@ module Koala
 
       def parse_media_args(media_args, method)
         # photo and video uploads can accept different types of arguments (see above)
-        # so here, we parse the arguments into a form directly usable in put_object
+        # so here, we parse the arguments into a form directly usable in put_connections
         raise KoalaError.new("Wrong number of arguments for put_#{method == "photos" ? "picture" : "video"}") unless media_args.size.between?(1, 5)
 
         args_offset = media_args[1].kind_of?(Hash) || media_args.size == 1 ? 0 : 1

--- a/readme.md
+++ b/readme.md
@@ -23,17 +23,17 @@ Or in Bundler:
 Graph API
 ----
 The Graph API is the simple, slick new interface to Facebook's data.  Using it with Koala is quite straightforward:
-  
+
     @graph = Koala::Facebook::API.new(oauth_access_token)
     # in 1.1 or earlier, use GraphAPI instead of API
-    
+
     profile = @graph.get_object("me")
     friends = @graph.get_connections("me", "friends")
-    @graph.put_object("me", "feed", :message => "I am writing on my wall!")
-   
+    @graph.put_connections("me", "feed", :message => "I am writing on my wall!")
+
     # three-part queries are easy too!
     @graph.get_connections("me", "mutualfriends/#{friend_id}")
-    
+
     # you can even use the new Timeline API
     # see https://developers.facebook.com/docs/beta/opengraph/tutorial/
     @graph.put_connections("me", "namespace:action", :object => object_url)
@@ -70,7 +70,7 @@ Fortunately, Koala supports the REST API using the very same interface; to use t
 
     @rest = Koala::Facebook::API.new(oauth_access_token)
     # in 1.1 or earlier, use RestAPI instead of API
-  	
+
   	@rest.fql_query(my_fql_query) # convenience method
   	@rest.fql_multiquery(fql_query_hash) # convenience method
   	@rest.rest_call("stream.publish", arguments_hash) # generic version
@@ -79,11 +79,11 @@ Of course, you can use the Graph API methods on the same object -- the power of 
 
     @api = Koala::Facebook::API.new(oauth_access_token)
     # in 1.1 or earlier, use GraphAndRestAPI instead of API
-    
+
     @api = Koala::Facebook::API.new(oauth_access_token)
     fql = @api.fql_query(my_fql_query)
     @api.put_wall_post(process_result(fql))
-    
+
 
 OAuth
 -----
@@ -166,7 +166,7 @@ Koala uses Faraday to make HTTP requests, which means you have complete control 
     }
     # or on a per-request basis
     @api.get_object(id, args_hash, { :timeout => 10 })
-  
+
 The <a href="https://github.com/arsduo/koala/wiki/HTTP-Services">HTTP Services wiki page</a> has more information on what options are available, as well as on how to configure your own Faraday middleware stack (for instance, to implement request logging).
 
 See examples, ask questions

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -592,10 +592,13 @@ shared_examples_for "Koala GraphAPI without an access token" do
   end
 
   it "can't put an object" do
+    lambda { @result = @api.put_connections(KoalaTest.user2, "feed", :message => "Hello, world") }.should raise_error(Koala::Facebook::APIError)
+    # legacy put_object syntax
     lambda { @result = @api.put_object(KoalaTest.user2, "feed", :message => "Hello, world") }.should raise_error(Koala::Facebook::APIError)
   end
 
-  # these are not strictly necessary as the other put methods resolve to put_object, but are here for completeness
+  # these are not strictly necessary as the other put methods resolve to put_connections,
+  # but are here for completeness
   it "can't post to a feed" do
     (lambda do
       attachment = {:name => "OAuth Playground", :link => "http://oauth.twoalex.com/"}


### PR DESCRIPTION
put_object should really do a POST on an individual object, not on a connection, despite the original design of Facebook's PHP library.
