### PR TITLE
Add link to Graph API Explorer in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,10 @@ gem "koala"
 
 Graph API
 ----
-The Graph API is the simple, slick new interface to Facebook's data.  Using it with Koala is quite straightforward:
+The Graph API is the simple, slick new interface to Facebook's data.  To obtain an access token to explore with,
+visit the [Graph API Explorer](https://developers.facebook.com/tools/explorer) and click on 'Get Access Token'.
+Using it with Koala is quite straightforward:
+
 ```ruby
 @graph = Koala::Facebook::API.new(oauth_access_token)
 # in 1.1 or earlier, use GraphAPI instead of API


### PR DESCRIPTION
I ended up writing a simple web app and outputting the access token, but Facebook's API Explorer allows you to generate one for quick testing.
