### PR TITLE
Parse paging urls with Addressable::URI.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :test do
   if RUBY_PLATFORM =~ /darwin/
     # OS X integration
     gem "ruby_gntp"
-    gem "rb-fsevent", :git => 'git://github.com/ttilley/rb-fsevent.git', :branch => 'pre-compiled-gem-one-off'
+    gem "rb-fsevent"
   end
 end
 

--- a/koala.gemspec
+++ b/koala.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency(%q<multi_json>,    ["~> 1.3"])
   gem.add_runtime_dependency(%q<faraday>,       ["~> 0.8"])
+  gem.add_runtime_dependency(%q<addressable>,   ["~> 2.2"])
   gem.add_development_dependency(%q<rspec>,     ["~> 2.8"])
   gem.add_development_dependency(%q<rake>,      ["~> 0.8"])
 end

--- a/lib/koala/api/graph_collection.rb
+++ b/lib/koala/api/graph_collection.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 module Koala
   module Facebook
     class API
@@ -87,7 +89,7 @@ module Koala
         #
         # @return an array of parameters that can be provided via graph_call(*parsed_params)
         def self.parse_page_url(url)
-          uri = URI.parse(url)
+          uri = Addressable::URI.parse(url)
 
           base = uri.path.sub(/^\//, '')
           params = CGI.parse(uri.query)


### PR DESCRIPTION
Non-encoded urls that Facebook passes back were failing to parse.

Seeing this error when requesting via the batch api and _not_ passing an access_token in the individual batch request.

From the internals of [graph_collection.rb:90](https://github.com/arsduo/koala/blob/master/lib/koala/api/graph_collection.rb#L90)

``` ruby
# note the vertical bar that signifies and application access token (generated from ::OAuth)

URI::InvalidURIError: bad URI(is not URI?): https://graph.facebook.com/...?access_token=appid123a|fdcba
```
