### PR TITLE
Using matches_url is enough. Use 'before :each' instead of 'before :all'...

### DIFF
--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -295,13 +295,13 @@ describe "Koala::Facebook::OAuth" do
 
       it "generates a properly formatted OAuth token URL when provided a code" do
         url = @oauth.url_for_access_token(@code)
-        url.should match_url("https://#{Koala::Facebook::GRAPH_SERVER}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape @callback_url}").should be_true
+        url.should match_url("https://#{Koala::Facebook::GRAPH_SERVER}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape @callback_url}")
       end
 
       it "generates a properly formatted OAuth token URL when provided a callback" do
         callback = "foo.com"
         url = @oauth.url_for_access_token(@code, :callback => callback)
-        url.should match_url("https://#{Koala::Facebook::GRAPH_SERVER}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape callback}").should be_true
+        url.should match_url("https://#{Koala::Facebook::GRAPH_SERVER}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape callback}")
       end
 
       it "includes any additional options as URL parameters, appropriately escaped" do

--- a/spec/cases/realtime_updates_spec.rb
+++ b/spec/cases/realtime_updates_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Koala::Facebook::RealtimeUpdates" do
-  before :all do
+  before :each do
     # get oauth data
     @app_id = KoalaTest.app_id
     @secret = KoalaTest.secret

--- a/spec/cases/test_users_spec.rb
+++ b/spec/cases/test_users_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Koala::Facebook::TestUsers" do
-  before :all do
+  before :each do
     # get oauth data
     @app_id = KoalaTest.app_id
     @secret = KoalaTest.secret
@@ -12,13 +12,6 @@ describe "Koala::Facebook::TestUsers" do
     # check OAuth data
     unless @app_id && @secret && @app_access_token
       raise Exception, "Must supply OAuth app id, secret, app_access_token, and callback to run live subscription tests!"
-    end
-  end
-  
-  after :each do
-    # clean up any test users
-    ((@network || []) + [@user1, @user2]).each do |u|
-      puts "Unable to delete test user #{u.inspect}" if u && !(@test_users.delete(u) rescue false)
     end
   end
 

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -413,7 +413,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
   end
 
   describe "#set_app_restrictions" do
-    before :all do
+    before :each do
       oauth = Koala::Facebook::OAuth.new(KoalaTest.app_id, KoalaTest.secret)
       app_token = oauth.get_app_access_token
       @app_api = Koala::Facebook::API.new(app_token)


### PR DESCRIPTION
Using matches_url is enough. Use 'before :each' instead of 'before :all' to simplify test cleanup logic.

Using `before(:all) do` is evil.
