### PR TITLE
Issue #237: All graph API methods take a post-processing block

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ Documentation:
 * Code highlighting in readme (thanks, sfate!)
 * Added Graph API explorer link in readme (thanks, jch!)
 * Added permissions example for OAuth (thanks, sebastiandeutsch!)
+* Every graph API method now accepts a post processing block. This is particularly
+useful for batch operations to separate concerns, see Readme for examles. (thanks, wolframarnold!)
 
 v1.5
 New methods:

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,9 @@ friends = @graph.get_connections("me", "friends")
 
 The response of most requests is the JSON data returned from the Facebook servers as a Hash.
 
-When retrieving data that returns an array of results (for example, when calling API#get_connections or API#search) a GraphCollection object will be returned, which makes it easy to page through the results:
+When retrieving data that returns an array of results (for example, when calling `API#get_connections` or `API#search`)
+a GraphCollection object will be returned, which makes it easy to page through the results:
+
 ```ruby
 # Returns the feed items for the currently logged-in user as a GraphCollection
 feed = @graph.get_connections("me", "feed")
@@ -67,6 +69,22 @@ You can also make multiple calls at once using Facebook's batch API:
   batch_api.put_wall_post('Making a post in a batch.')
 end
 ```
+
+You can pass a "post-processing" block to each of Koala's Graph API methods. This is handy for two reasons:
+
+1. You can modify the result returned by the Graph API method:
+
+        education = @graph.get_object("me") { |data| data['education'] }
+        # returned value only contains the "education" portion of the profile
+
+2. You can consume the data in place which is particularly useful in the batch case, so you don't have to pull
+the results apart from a long list of array entries:
+
+        @graph.batch do |batch_api|
+          # Assuming you have database fields "about_me" and "photos"
+          batch_api.get_object('me')                {|me|     self.about_me = me }
+          batch_api.get_connections('me', 'photos') {|photos| self.photos   = photos }
+        end
 
 Check out the wiki for more details and examples.
 

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'Koala::Facebook::GraphAPIMethods' do
+  before do
+    @api = Koala::Facebook::API.new(@token)
+    # app API
+    @app_id = KoalaTest.app_id
+    @app_access_token = KoalaTest.app_access_token
+    @app_api = Koala::Facebook::API.new(@app_access_token)
+  end
+
+  describe 'post-processing for' do
+    let(:post_processing) { lambda {} }
+
+    # Most API methods have the same signature, we test get_object representatively
+    # and the other methods which do some post-processing locally
+    context '#get_object' do
+      it 'is called' do
+        post_processing.should_receive(:call).with("id" => 1, "name" => 1, "updated_time" => 1)
+        @api.get_object('koppel', &post_processing)
+      end
+
+      it 'returns result of block' do
+        post_processing.should_receive(:call).and_return('new result')
+        @api.get_object('koppel', &post_processing).should == 'new result'
+      end
+    end
+
+    context '#get_picture' do
+      it ' is called with picture url' do
+        post_processing.should_receive(:call).with('http://facebook.com/')
+        @api.get_picture('lukeshepard', &post_processing)
+      end
+
+      it 'returns result of block' do
+        post_processing.should_receive(:call).and_return('new result')
+        @api.get_picture('lukeshepard', &post_processing).should == 'new result'
+      end
+    end
+
+    context '#fql_multiquery' do
+      before do
+        MultiJson.stub(:dump)
+        @api.should_receive(:get_object).and_return([{"name" => "query1", "fql_result_set" => [{"id" => 123}]},{"name" => "query2", "fql_result_set" => ["id" => 456]}])
+      end
+
+      it 'is called with resolved response' do
+        resolved_result = { 'query1'=>[{'id'=>123}],'query2'=>[{'id'=>456}] }
+        post_processing.should_receive(:call).with(resolved_result)
+        @api.fql_multiquery(&post_processing)
+      end
+
+      it 'returns result of block' do
+        post_processing.should_receive(:call).and_return('id'=>'123', 'id'=>'456')
+        @api.fql_multiquery(&post_processing).should == {'id'=>'123', 'id'=>'456'}
+      end
+    end
+
+    context '#get_page_access_token' do
+      it 'is called with just access token' do
+        post_processing.should_receive(:call).with(Koala::MockHTTPService::APP_ACCESS_TOKEN)
+        @api.get_page_access_token '/my_page', &post_processing
+      end
+
+      it 'returns result of block' do
+        post_processing.should_receive(:call).and_return('base64-encoded access token')
+        @api.get_page_access_token('/my_page', &post_processing).should == 'base64-encoded access token'
+      end
+    end
+
+  end
+
+end

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -82,7 +82,7 @@ graph_api:
         with_token: '[{"code": 200, "headers":[{"name":"Location","value":"http://google.com"}]}]'
     batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "me/friends"}]) %>:
       post:
-        with_token: '[{"code": 200, "body":"{\"id\":\"123\"}"}, {"code": 200, "body":"{\"data\":[],\"paging\":{}}"}]'
+        with_token: '[{"code": 200, "body":"{\"id\":\"123\"}"}, {"code": 200, "body":"{\"data\":[{\"id\":\"456\"}],\"paging\":{}}"}]'
     batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"me"}, {"method"=>"get", "relative_url"=>"#{OAUTH_DATA["app_id"]}/insights?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"id\":\"123\"}"}, {"code": 200, "body":"{\"data\":[],\"paging\":{}}"}]'


### PR DESCRIPTION
Implements proposal laid out in Issue #237:
Each Graph API method now takes an optional post-processing block. The result data is passed to the block for post-processing. The return value of the method is the result of the block, if provided.
This also now exposes the previously existing but hidden mechanism to pass a block to batched Graph API calls. The post-processing block received GraphCollections, not raw data. Technically
an API-breaking change, but the block interface was never exposed, so it wouldn't affect users of the high-level API's.
Tests included and Readme updated with examples.
