### PR TITLE
Parse media urls with Addressable::URI

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 require 'koala/api/graph_collection'
 require 'koala/http_service/uploadable_io'
 
@@ -536,9 +538,9 @@ module Koala
       def url?(data)
         return false unless data.is_a? String
         begin
-          uri = URI.parse(data)
+          uri = Addressable::URI.parse(data)
           %w( http https ).include?(uri.scheme)
-        rescue URI::BadURIError
+        rescue Addressable::URI::InvalidURIError
           false
         end
       end


### PR DESCRIPTION
When providing a media url with an unicode char the error URI::InvalidURIError: bad URI(is not URI?) is thrown. Using Addressable::URI.parse solves this issue.

This fix is similar to pull request https://github.com/arsduo/koala/pull/233 / issue #223 where the same error occurred and switching to Addressable solved the issue.
