### PR TITLE
Add support for debug_token

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -369,6 +369,8 @@ module Koala
       end
 
       # Get an access token information
+      # The access token used to instantiate the API object needs to be
+      # the app access token or a valid User Access Token from a developer of the app.
       # See https://developers.facebook.com/docs/howtos/login/debugging-access-tokens/#step1
       #
       # @param input_token the access token you want to inspect

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -309,7 +309,7 @@ graph_api:
         with_token: "true"
 
   /debug_token:
-    input_token=this_is_an_access_token:
+    input_token=<%= APP_ACCESS_TOKEN %>:
       get:
         with_token: '{ "data": { "app_id": 138483919580948, "application": "Social Cafe", "expires_at": 1352419328, "is_valid": true, "issued_at": 1347235328, "metadata": { "sso": "iphone-safari" }, "scopes": [ "email", "publish_actions" ], "user_id": 1207059 } }'
 

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -413,24 +413,11 @@ shared_examples_for "Koala GraphAPI with an access token" do
   end
 
   it "can get information about an access token" do
-    result = @api.debug_token("this_is_an_access_token")
-    result.should == {
-        "data" => {
-            "app_id" => 138483919580948, 
-            "application" => "Social Cafe", 
-            "expires_at" => 1352419328, 
-            "is_valid" => true, 
-            "issued_at" => 1347235328, 
-            "metadata" => {
-                "sso" => "iphone-safari"
-            }, 
-            "scopes" => [
-                "email", 
-                "publish_actions"
-            ], 
-            "user_id" => 1207059
-        }
-    }
+    result = @api.debug_token(KoalaTest.app_access_token)
+    result.should be_kind_of(Hash)
+    result["data"].should be_kind_of(Hash)
+    result["data"]["app_id"].should == 138483919580948
+    result["data"]["application"].should == "Social Cafe"
   end
 
   describe "#set_app_restrictions" do


### PR DESCRIPTION
I needed to get information about an access token and realized that the debug_token entry point of the graph api wasn't directly available.

So here it is.
