### PR TITLE
Fix for getting application access_token

### DIFF
--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -175,7 +175,7 @@ module Koala
       # @return the application access token and other information (expiration, etc.)
       def get_app_access_token_info(options = {})
         # convenience method to get a the application's sessionless access token
-        get_token_from_server({:type => 'client_cred'}, true, options)
+        get_token_from_server({:grant_type => 'client_credentials'}, true, options)
       end
 
       # Fetches the application's access token (ignoring expiration and other info).


### PR DESCRIPTION
...ed for get_app_access_token_info

Complying with Facebook documentation (https://developers.facebook.com/docs/howtos/login/login-as-app/), app login flow should use 'grant_type' (not 'type') parameter and should request 'client_credentials'
