### PR TITLE
Support for Faraday with Typhoeus 0.5

### DIFF
--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'typhoeus/adapters/faraday'
 require 'koala/http_service/multipart_request'
 require 'koala/http_service/uploadable_io'
 require 'koala/http_service/response'


### PR DESCRIPTION
See https://github.com/typhoeus/typhoeus/issues/226#issuecomment-9919517

> Faraday does not support Typhoeus 0.5. If you want to use Typhoeus 0.5 with Faraday you have to `require typhoeus/adapters/faraday`.
