### PR TITLE
Makes it possible to pass in basic request parameters as arrays

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -42,6 +42,7 @@ module Koala
       # @return the body of the response from Facebook (unless another http_component is requested)
       def api(path, args = {}, verb = "get", options = {}, &error_checking_block)
         # Fetches the given path in the Graph API.
+        args = sanitize_request_parameters(args)
         args["access_token"] = @access_token || @app_access_token if @access_token || @app_access_token
 
         # add a leading /
@@ -64,6 +65,16 @@ module Koala
           # Note: Facebook sometimes sends results like "true" and "false", which aren't strictly objects
           # and cause MultiJson.load to fail -- so we account for that by wrapping the result in []
           MultiJson.load("[#{result.body.to_s}]")[0]
+        end
+      end
+
+      private
+
+      def sanitize_request_parameters(parameters)
+        parameters.reduce({}) do |result, (key, value)|
+          value = value.join(",") if value && value.is_a?(Array) && value.none?{|entry| entry.is_a?(Enumerable)}
+          result[key] = value
+          result
         end
       end
     end

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -54,6 +54,14 @@ describe "Koala::Facebook::API" do
     @service.api('anything', {}, 'get', :http_component => http_component).should == response
   end
 
+  it "should extract arrays into comma-separated arguments" do
+      args = [12345, {:foo => [1, 2, 3, 4]}]
+      expected = ["/12345", {:foo => "1,2,3,4"}, "get", {}]
+      response = mock('Mock KoalaResponse', :body => '', :status => 200)
+      Koala.should_receive(:make_request).with(*expected).and_return(response)
+      @service.api(*args)
+    end
+
   it "returns the body of the request as JSON if no http_component is given" do
     response = stub('response', :body => 'body', :status => 200)
     Koala.stub(:make_request).and_return(response)


### PR DESCRIPTION
For example it wasn't possible to send invite requests as follows:

``` ruby
@graph.put_connections(1234567, "invited", :users => [1,2,3,4,5])
```

Instead in order to work with the API you'd need to do something
similar to:

``` ruby
user_ids = [1,2,3,4,5].join(',')
@graph.put_connections(1234567, "invited", :users => user_ids)
```

This fixes that.
