### PR TITLE
Handle batch operation-specific access_tokens while paging results

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -42,7 +42,7 @@ module Koala
       # @return the body of the response from Facebook (unless another http_component is requested)
       def api(path, args = {}, verb = "get", options = {}, &error_checking_block)
         # Fetches the given path in the Graph API.
-        args["access_token"] = @access_token || @app_access_token if @access_token || @app_access_token
+        args["access_token"] ||= @access_token || @app_access_token if @access_token || @app_access_token
 
         # add a leading /
         path = "/#{path}" unless path =~ /^\//


### PR DESCRIPTION
It looks like the API-level access token rather than the BatchOperation-level access token is being used when paging results. This is the fix I am using along with a new test.
