### PR TITLE
Accepts Tempfile as File objects in UploadableIO

### DIFF
--- a/lib/koala/http_service/uploadable_io.rb
+++ b/lib/koala/http_service/uploadable_io.rb
@@ -1,4 +1,5 @@
 require "net/http/post/multipart"
+require "tempfile"
 
 module Koala
   module HTTPService
@@ -80,7 +81,7 @@ module Koala
 
       # takes a file object
       def self.file_param?(file)
-        file.kind_of?(File)
+        file.kind_of?(File) || file.kind_of?(Tempfile)
       end
 
       def parse_file_object(file, content_type = nil)
@@ -180,7 +181,7 @@ module Koala
       end
     end
   end
-  
+
   # @private
   # legacy support for when UploadableIO lived directly under Koala
   UploadableIO = HTTPService::UploadableIO

--- a/spec/cases/uploadable_io_spec.rb
+++ b/spec/cases/uploadable_io_spec.rb
@@ -86,6 +86,38 @@ describe "Koala::UploadableIO" do
       end
     end
 
+
+    describe "when given a Tempfile object" do
+      before(:each) do
+        @file = Tempfile.new('coucou')
+        @koala_io_params = [@file]
+      end
+
+      describe "and a content type" do
+        before :each do
+          @koala_io_params.concat(["image/jpg"])
+        end
+
+        it "returns an UploadIO with the same io" do
+          #Problem comparing Tempfile in Ruby 1.8, REE and Rubinius mode 1.8
+          Koala::UploadableIO.new(*@koala_io_params).io_or_path.path.should == @koala_io_params[0].path
+        end
+
+        it "returns an UploadableIO with the same content_type" do
+          content_stub = @koala_io_params[1] = stub('Content Type')
+          Koala::UploadableIO.new(*@koala_io_params).content_type.should == content_stub
+        end
+
+        it "returns an UploadableIO with the right filename" do
+          Koala::UploadableIO.new(*@koala_io_params).filename.should == File.basename(@file.path)
+        end
+      end
+
+      describe "and no content type" do
+        it_should_behave_like "determining a mime type"
+      end
+    end
+
     describe "when given an IO object" do
       before(:each) do
         @io = StringIO.open("abcdefgh")


### PR DESCRIPTION
Tempfiles are just Files with delegate

If Tempfile are not threated like File, it goes to the IO category and does not detect MimeType.

I had some issues with that and thought it would be nice to add this feature as it was easy.
