### PR TITLE
Raise an error on RealtimeUpdates::validate_update if @secret is not set

### DIFF
--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -7,6 +7,9 @@ module Koala
     # The OAuth signature is incomplete, invalid, or using an unsupported algorithm
     class OAuthSignatureError < ::Koala::KoalaError; end
 
+    # Required for realtime updates validation
+    class AppSecretNotDefinedError < ::Koala::KoalaError; end
+
     # Facebook responded with an error to an API request. If the exception contains a nil
     # http_status, then the error was detected before making a call to Facebook. (e.g. missing access token)
     class APIError < ::Koala::KoalaError

--- a/lib/koala/realtime_updates.rb
+++ b/lib/koala/realtime_updates.rb
@@ -125,6 +125,10 @@ module Koala
       #     end
       #   end
       def validate_update(body, headers)
+        if @secret == nil
+          raise AppSecretNotDefinedError, "You must init RealtimeUpdates with your app secret in order to validate updates"
+        end
+
         if request_signature = headers['X-Hub-Signature'] || headers['HTTP_X_HUB_SIGNATURE'] and
            signature_parts = request_signature.split("sha1=")
           request_signature = signature_parts[1]


### PR DESCRIPTION
RealtimeUpdates::validate_update requires @secret to be set in the RealtimeUpdates
instance.

But the RealtimeUpdates can be initialized without it (with @app_access_token instead),
in which case validate_update will break.
