### PR TITLE
fix TestUsers.delete_all infinite loop detection

### DIFF
--- a/lib/koala/test_users.rb
+++ b/lib/koala/test_users.rb
@@ -96,7 +96,7 @@ module Koala
         while (test_user_list = list(options)).length > 0
           # avoid infinite loops if Facebook returns buggy users you can't delete
           # see http://developers.facebook.com/bugs/223629371047398
-          break if test_user_list == previous_list
+          break if (test_user_list.map{|u|u['id']} - (previous_list||[]).map{|u|u['id']}).empty?
 
           test_user_list.each_slice(50) do |users| 
             self.api.batch(options) {|batch_api| users.each {|u| batch_api.delete_object(u["id"]) }}


### PR DESCRIPTION
User hashes can change across list() invocations, so that test_user_list may not equal previous_list, even if the logical users are identical.  Mapping the user hashes to the ids fixes this.
