### PR TITLE
Add new Rubinius requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rvm:
   - 2.0.0
   - ruby-head
   # rbx
-  - rbx-19mode
   - rbx-2.1.1
+  - rbx
   # jruby
   - jruby-19mode
   - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,10 @@ end
 
 gem "jruby-openssl" if defined? JRUBY_VERSION
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'         # if using anything in the ruby standard library
+  gem 'psych'                    # if using yaml
+  gem 'rubinius-developer_tools' # if using any of coverage, debugger, profiler
+end
+
 gemspec


### PR DESCRIPTION
There have been some rubinius related changes that impact how rbx specs run on Travis CI.  There's some discussion here - http://www.benjaminfleischer.com/2013/12/05/testing-rubinius-on-travis-ci/

This PR includes changes to the Gemfile and .travis.yml to make these specs run green.
