### PR TITLE
Added that connections take the singular form when using put_connections...

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -119,7 +119,8 @@ module Koala
 
       # Write an object to the Graph for a specific user.
       # See {http://developers.facebook.com/docs/api#publishing Facebook's documentation}
-      # for all the supported writeable objects.
+      # for all the supported writeable objects. It is important to note that objects 
+      # take the singular form, i.e. "event" when using put_connections.
       #
       # @note (see #get_connection)
       #


### PR DESCRIPTION
The documentation mentions using the plural form for objects to get_connections from but neglects to say that the singular form is necessary when putting an object (put_connections). For example:

```
@graph.put_connections("facebook_object_id", "event", description: "New description text.")
```

This helped me out, hope it helps others!
