### PR TITLE
Update specs to run cleanly without deprecation warnings under RSpec 3.0.x

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("multi_json")
   gem.add_runtime_dependency("faraday")
   gem.add_runtime_dependency("addressable")
-  gem.add_development_dependency("rspec")
+  gem.add_development_dependency("rspec", '~> 3.0.0.beta1')
   gem.add_development_dependency("rake")
 end

--- a/lib/koala/http_service/multipart_request.rb
+++ b/lib/koala/http_service/multipart_request.rb
@@ -14,9 +14,9 @@ module Koala
       def process_request?(env)
         # if the request values contain any hashes or arrays, multipart it
         super || !!(env[:body].respond_to?(:values) && env[:body].values.find {|v| v.is_a?(Hash) || v.is_a?(Array)})
-      end   
+      end
     
-    
+
       def process_params(params, prefix = nil, pieces = nil, &block)
         params.inject(pieces || []) do |all, (key, value)|
           key = "#{prefix}%5B#{key}%5D" if prefix

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -6,7 +6,7 @@ describe "Koala::Facebook::API" do
   end
 
   it "doesn't include an access token if none was given" do
-    Koala.should_receive(:make_request).with(
+    expect(Koala).to receive(:make_request).with(
       anything,
       hash_not_including('access_token' => 1),
       anything,
@@ -20,7 +20,7 @@ describe "Koala::Facebook::API" do
     token = 'adfadf'
     service = Koala::Facebook::API.new token
 
-    Koala.should_receive(:make_request).with(
+    expect(Koala).to receive(:make_request).with(
       anything,
       hash_including('access_token' => token),
       anything,
@@ -33,7 +33,7 @@ describe "Koala::Facebook::API" do
   it "has an attr_reader for access token" do
     token = 'adfadf'
     service = Koala::Facebook::API.new token
-    service.access_token.should == token
+    expect(service.access_token).to eq(token)
   end
 
   it "gets the attribute of a Koala::HTTPService::Response given by the http_component parameter" do
@@ -41,24 +41,24 @@ describe "Koala::Facebook::API" do
 
     response = double('Mock KoalaResponse', :body => '', :status => 200)
     result = double("result")
-    response.stub(http_component).and_return(result)
-    Koala.stub(:make_request).and_return(response)
+    allow(response).to receive(http_component).and_return(result)
+    allow(Koala).to receive(:make_request).and_return(response)
 
-    @service.api('anything', {}, 'get', :http_component => http_component).should == result
+    expect(@service.api('anything', {}, 'get', :http_component => http_component)).to eq(result)
   end
 
   it "returns the entire response if http_component => :response" do
     http_component = :response
     response = double('Mock KoalaResponse', :body => '', :status => 200)
-    Koala.stub(:make_request).and_return(response)
-    @service.api('anything', {}, 'get', :http_component => http_component).should == response
+    allow(Koala).to receive(:make_request).and_return(response)
+    expect(@service.api('anything', {}, 'get', :http_component => http_component)).to eq(response)
   end
 
   it "turns arrays of non-enumerables into comma-separated arguments" do
     args = [12345, {:foo => [1, 2, "3", :four]}]
     expected = ["/12345", {:foo => "1,2,3,four"}, "get", {}]
     response = double('Mock KoalaResponse', :body => '', :status => 200)
-    Koala.should_receive(:make_request).with(*expected).and_return(response)
+    expect(Koala).to receive(:make_request).with(*expected).and_return(response)
     @service.api(*args)
   end
 
@@ -70,57 +70,57 @@ describe "Koala::Facebook::API" do
     # or raise an exception
     expected = ["/12345", params, "get", {}]
     response = double('Mock KoalaResponse', :body => '', :status => 200)
-    Koala.should_receive(:make_request).with(*expected).and_return(response)
+    expect(Koala).to receive(:make_request).with(*expected).and_return(response)
     @service.api(*args)
   end
 
   it "returns the body of the request as JSON if no http_component is given" do
     response = double('response', :body => 'body', :status => 200)
-    Koala.stub(:make_request).and_return(response)
+    allow(Koala).to receive(:make_request).and_return(response)
 
     json_body = double('JSON body')
-    MultiJson.stub(:load).and_return([json_body])
+    allow(MultiJson).to receive(:load).and_return([json_body])
 
-    @service.api('anything').should == json_body
+    expect(@service.api('anything')).to eq(json_body)
   end
 
   it "executes an error checking block if provided" do
     response = Koala::HTTPService::Response.new(200, '{}', {})
-    Koala.stub(:make_request).and_return(response)
+    allow(Koala).to receive(:make_request).and_return(response)
 
     yield_test = double('Yield Tester')
-    yield_test.should_receive(:pass)
+    expect(yield_test).to receive(:pass)
 
     @service.api('anything', {}, "get") do |arg|
       yield_test.pass
-      arg.should == response
+      expect(arg).to eq(response)
     end
   end
 
   it "raises an API error if the HTTP response code is greater than or equal to 500" do
-    Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(500, 'response body', {}))
+    allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(500, 'response body', {}))
 
-    lambda { @service.api('anything') }.should raise_exception(Koala::Facebook::APIError)
+    expect { @service.api('anything') }.to raise_exception(Koala::Facebook::APIError)
   end
 
   it "handles rogue true/false as responses" do
-    Koala.should_receive(:make_request).and_return(Koala::HTTPService::Response.new(200, 'true', {}))
-    @service.api('anything').should be true
+    expect(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, 'true', {}))
+    expect(@service.api('anything')).to be true
 
-    Koala.should_receive(:make_request).and_return(Koala::HTTPService::Response.new(200, 'false', {}))
-    @service.api('anything').should be false
+    expect(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, 'false', {}))
+    expect(@service.api('anything')).to be false
   end
 
   describe "with regard to leading slashes" do
     it "adds a leading / to the path if not present" do
       path = "anything"
-      Koala.should_receive(:make_request).with("/#{path}", anything, anything, anything).and_return(Koala::HTTPService::Response.new(200, 'true', {}))
+      expect(Koala).to receive(:make_request).with("/#{path}", anything, anything, anything).and_return(Koala::HTTPService::Response.new(200, 'true', {}))
       @service.api(path)
     end
 
     it "doesn't change the path if a leading / is present" do
       path = "/anything"
-      Koala.should_receive(:make_request).with(path, anything, anything, anything).and_return(Koala::HTTPService::Response.new(200, 'true', {}))
+      expect(Koala).to receive(:make_request).with(path, anything, anything, anything).and_return(Koala::HTTPService::Response.new(200, 'true', {}))
       @service.api(path)
     end
   end

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -2,23 +2,23 @@ require 'spec_helper'
 
 describe Koala::Facebook::APIError do
   it "is a Koala::KoalaError" do
-    Koala::Facebook::APIError.new(nil, nil).should be_a(Koala::KoalaError)
+    expect(Koala::Facebook::APIError.new(nil, nil)).to be_a(Koala::KoalaError)
   end
 
   [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :http_status, :response_body].each do |accessor|
     it "has an accessor for #{accessor}" do
-      Koala::Facebook::APIError.instance_methods.map(&:to_sym).should include(accessor)
-      Koala::Facebook::APIError.instance_methods.map(&:to_sym).should include(:"#{accessor}=")
+      expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(accessor)
+      expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(:"#{accessor}=")
     end
   end
 
   it "sets http_status to the provided status" do
     error_response = '{ "error": {"type": "foo", "other_details": "bar"} }'
-    Koala::Facebook::APIError.new(400, error_response).response_body.should == error_response
+    expect(Koala::Facebook::APIError.new(400, error_response).response_body).to eq(error_response)
   end
 
   it "sets response_body to the provided response body" do
-    Koala::Facebook::APIError.new(400, '').http_status.should == 400
+    expect(Koala::Facebook::APIError.new(400, '').http_status).to eq(400)
   end
 
   context "with an error_info hash" do
@@ -39,12 +39,12 @@ describe Koala::Facebook::APIError do
       :fb_error_subcode => 'subcode'
     }.each_pair do |accessor, value|
       it "sets #{accessor} to #{value}" do
-        error.send(accessor).should == value
+        expect(error.send(accessor)).to eq(value)
       end
     end
 
     it "sets the error message \"type: error_info['type'], code: error_info['code'], error_subcode: error_info['error_subcode'], message: error_info['message'] [HTTP http_status]\"" do
-      error.message.should == "type: type, code: 1, error_subcode: subcode, message: message [HTTP 400]"
+      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message [HTTP 400]")
     end
   end
 
@@ -52,7 +52,7 @@ describe Koala::Facebook::APIError do
     it "sets the error message \"error_info [HTTP http_status]\"" do
       error_info = "Facebook is down."
       error = Koala::Facebook::APIError.new(400, '', error_info)
-      error.message.should == "Facebook is down. [HTTP 400]"
+      expect(error.message).to eq("Facebook is down. [HTTP 400]")
     end
   end
 
@@ -66,7 +66,7 @@ describe Koala::Facebook::APIError do
         :fb_error_code => 1,
         :fb_error_subcode => 'subcode'
       }.each_pair do |accessor, value|
-        error.send(accessor).should == value
+        expect(error.send(accessor)).to eq(value)
       end
     end
   end
@@ -75,42 +75,42 @@ end
 
 describe Koala::KoalaError do
   it "is a StandardError" do
-     Koala::KoalaError.new.should be_a(StandardError)
+     expect(Koala::KoalaError.new).to be_a(StandardError)
   end
 end
 
 describe Koala::Facebook::OAuthSignatureError do
   it "is a Koala::KoalaError" do
-     Koala::KoalaError.new.should be_a(Koala::KoalaError)
+     expect(Koala::KoalaError.new).to be_a(Koala::KoalaError)
   end
 end
 
 describe Koala::Facebook::BadFacebookResponse do
   it "is a Koala::Facebook::APIError" do
-     Koala::Facebook::BadFacebookResponse.new(nil, nil).should be_a(Koala::Facebook::APIError)
+     expect(Koala::Facebook::BadFacebookResponse.new(nil, nil)).to be_a(Koala::Facebook::APIError)
   end
 end
 
 describe Koala::Facebook::OAuthTokenRequestError do
   it "is a Koala::Facebook::APIError" do
-     Koala::Facebook::OAuthTokenRequestError.new(nil, nil).should be_a(Koala::Facebook::APIError)
+     expect(Koala::Facebook::OAuthTokenRequestError.new(nil, nil)).to be_a(Koala::Facebook::APIError)
   end
 end
 
 describe Koala::Facebook::ServerError do
   it "is a Koala::Facebook::APIError" do
-     Koala::Facebook::ServerError.new(nil, nil).should be_a(Koala::Facebook::APIError)
+     expect(Koala::Facebook::ServerError.new(nil, nil)).to be_a(Koala::Facebook::APIError)
   end
 end
 
 describe Koala::Facebook::ClientError do
   it "is a Koala::Facebook::APIError" do
-     Koala::Facebook::ClientError.new(nil, nil).should be_a(Koala::Facebook::APIError)
+     expect(Koala::Facebook::ClientError.new(nil, nil)).to be_a(Koala::Facebook::APIError)
   end
 end
 
 describe Koala::Facebook::AuthenticationError do
   it "is a Koala::Facebook::ClientError" do
-     Koala::Facebook::AuthenticationError.new(nil, nil).should be_a(Koala::Facebook::ClientError)
+     expect(Koala::Facebook::AuthenticationError.new(nil, nil)).to be_a(Koala::Facebook::ClientError)
   end
 end

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -24,26 +24,26 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
     describe ".new" do
       it "makes http_options accessible" do
-        Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).http_options.should == @args[:http_options]
+        expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).http_options).to eq(@args[:http_options])
       end
 
       it "makes post_processing accessible" do
-        Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).post_processing.should == @args[:post_processing]
+        expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).post_processing).to eq(@args[:post_processing])
       end
 
       it "makes access_token accessible" do
-        Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).access_token.should == @args[:access_token]
+        expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).access_token).to eq(@args[:access_token])
       end
 
       it "doesn't change the original http_options" do
         @args[:http_options][:name] = "baz2"
         expected = @args[:http_options].dup
         Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)
-        @args[:http_options].should == expected
+        expect(@args[:http_options]).to eq(expected)
       end
 
       it "leaves the file array nil by default" do
-        Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).files.should be_nil
+        expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).files).to be_nil
       end
 
       it "raises a KoalaError if no access token supplied" do
@@ -56,13 +56,13 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           @uploadable_io = double("UploadableIO 1")
 
           @batch_queue = []
-          Koala::Facebook::GraphAPI.stub(:batch_calls).and_return(@batch_queue)
+          allow(Koala::Facebook::GraphAPI).to receive(:batch_calls).and_return(@batch_queue)
 
-          Koala::UploadableIO.stub(:new).with(@binary).and_return(@uploadable_io)
-          Koala::UploadableIO.stub(:binary_content?).and_return(false)
-          Koala::UploadableIO.stub(:binary_content?).with(@binary).and_return(true)
-          Koala::UploadableIO.stub(:binary_content?).with(@uploadable_io).and_return(true)
-          @uploadable_io.stub(:is_a?).with(Koala::UploadableIO).and_return(true)
+          allow(Koala::UploadableIO).to receive(:new).with(@binary).and_return(@uploadable_io)
+          allow(Koala::UploadableIO).to receive(:binary_content?).and_return(false)
+          allow(Koala::UploadableIO).to receive(:binary_content?).with(@binary).and_return(true)
+          allow(Koala::UploadableIO).to receive(:binary_content?).with(@uploadable_io).and_return(true)
+          allow(@uploadable_io).to receive(:is_a?).with(Koala::UploadableIO).and_return(true)
 
           @args[:method] = "post" # files are always post
         end
@@ -70,23 +70,23 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         it "adds binary files to the files attribute as UploadableIOs" do
           @args[:args].merge!("source" => @binary)
           batch_op = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args)
-          batch_op.files.should_not be_nil
-          batch_op.files.find {|k, v| v == @uploadable_io}.should_not be_nil
+          expect(batch_op.files).not_to be_nil
+          expect(batch_op.files.find {|k, v| v == @uploadable_io}).not_to be_nil
         end
 
         it "works if supplied an UploadableIO as an argument" do
           # as happens with put_picture at the moment
           @args[:args].merge!("source" => @uploadable_io)
           batch_op = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args)
-          batch_op.files.should_not be_nil
-          batch_op.files.find {|k, v| v == @uploadable_io}.should_not be_nil
+          expect(batch_op.files).not_to be_nil
+          expect(batch_op.files.find {|k, v| v == @uploadable_io}).not_to be_nil
         end
 
         it "assigns each binary parameter unique name" do
           @args[:args].merge!("source" => @binary, "source2" => @binary)
           batch_op = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args)
           # if the name wasn't unique, there'd just be one item
-          batch_op.files.size.should eq(2)
+          expect(batch_op.files.size).to eq(2)
         end
 
         it "assigns each binary parameter unique name across batch requests" do
@@ -97,12 +97,12 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_op2 = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args)
           @batch_queue << batch_op2
           # if the name wasn't unique, we should have < 4 items since keys would be the same
-          batch_op.files.merge(batch_op2.files).size.should eq(4)
+          expect(batch_op.files.merge(batch_op2.files).size).to eq(4)
         end
 
         it "removes the value from the arguments" do
           @args[:args].merge!("source" => @binary)
-          Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body].should_not =~ /source=/
+          expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body]).not_to match(/source=/)
         end
       end
 
@@ -114,49 +114,49 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           it "adds the args to the URL string, with ? if no args previously present" do
             test_args = "foo"
             @args[:url] = url = "/"
-            Koala.http_service.stub(:encode_params).and_return(test_args)
+            allow(Koala.http_service).to receive(:encode_params).and_return(test_args)
 
-            Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:relative_url].should == "#{url}?#{test_args}"
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:relative_url]).to eq("#{url}?#{test_args}")
           end
 
           it "adds the args to the URL string, with & if args previously present" do
             test_args = "foo"
             @args[:url] = url = "/?a=2"
-            Koala.http_service.stub(:encode_params).and_return(test_args)
+            allow(Koala.http_service).to receive(:encode_params).and_return(test_args)
 
-            Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:relative_url].should == "#{url}&#{test_args}"
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:relative_url]).to eq("#{url}&#{test_args}")
           end
 
           it "adds nothing to the URL string if there are no args to be added" do
             @args[:args] = {}
-            Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(@args[:access_token])[:relative_url].should == @args[:url]
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(@args[:access_token])[:relative_url]).to eq(@args[:url])
           end
 
           it "adds nothing to the body" do
-            Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body].should be_nil
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body]).to be_nil
           end
         end
 
         shared_examples_for "requests with a body param" do
           it "sets the body to the encoded args string, if there are args" do
             test_args = "foo"
-            Koala.http_service.stub(:encode_params).and_return(test_args)
+            allow(Koala.http_service).to receive(:encode_params).and_return(test_args)
 
-            Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body].should == test_args
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body]).to eq(test_args)
           end
 
           it "does not set the body if there are no args" do
             test_args = ""
-            Koala.http_service.stub(:encode_params).and_return(test_args)
-            Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body].should be_nil
+            allow(Koala.http_service).to receive(:encode_params).and_return(test_args)
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:body]).to be_nil
           end
 
 
           it "doesn't change the url" do
             test_args = "foo"
-            Koala.http_service.stub(:encode_params).and_return(test_args)
+            allow(Koala.http_service).to receive(:encode_params).and_return(test_args)
 
-            Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:relative_url].should == @args[:url]
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)[:relative_url]).to eq(@args[:url])
           end
         end
 
@@ -195,36 +195,36 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
       it "includes the access token if the token is not the main one for the request" do
          params = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)
-         params[:relative_url].should =~ /access_token=#{@args[:access_token]}/
+         expect(params[:relative_url]).to match(/access_token=#{@args[:access_token]}/)
       end
 
       it "includes the other arguments if the token is not the main one for the request" do
         @args[:args] = {:a => 2}
         params = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)
-        params[:relative_url].should =~ /a=2/
+        expect(params[:relative_url]).to match(/a=2/)
       end
 
       it "does not include the access token if the token is the main one for the request" do
          params = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(@args[:access_token])
-         params[:relative_url].should_not =~ /access_token=#{@args[:access_token]}/
+         expect(params[:relative_url]).not_to match(/access_token=#{@args[:access_token]}/)
       end
 
       it "includes the other arguments if the token is the main one for the request" do
         @args[:args] = {:a => 2}
         params = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(@args[:access_token])
-        params[:relative_url].should =~ /a=2/
+        expect(params[:relative_url]).to match(/a=2/)
       end
 
       it "includes any arguments passed as http_options[:batch_args]" do
         batch_args = {:name => "baz", :headers => {:some_param => true}}
         @args[:http_options][:batch_args] = batch_args
         params = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil)
-        params.should include(batch_args)
+        expect(params).to include(batch_args)
       end
 
       it "includes the method" do
         params = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(@args[:access_token])
-        params[:method].should == @args[:method].to_s
+        expect(params[:method]).to eq(@args[:method].to_s)
       end
 
       it "works with nil http_options" do
@@ -238,14 +238,14 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
       describe "with binary files" do
         before :each do
           @binary = double("Binary file")
-          Koala::UploadableIO.stub(:binary_content?).and_return(false)
-          Koala::UploadableIO.stub(:binary_content?).with(@binary).and_return(true)
+          allow(Koala::UploadableIO).to receive(:binary_content?).and_return(false)
+          allow(Koala::UploadableIO).to receive(:binary_content?).with(@binary).and_return(true)
           @uploadable_io = double("UploadableIO")
-          Koala::UploadableIO.stub(:new).with(@binary).and_return(@uploadable_io)
-          @uploadable_io.stub(:is_a?).with(Koala::UploadableIO).and_return(true)
+          allow(Koala::UploadableIO).to receive(:new).with(@binary).and_return(@uploadable_io)
+          allow(@uploadable_io).to receive(:is_a?).with(Koala::UploadableIO).and_return(true)
 
           @batch_queue = []
-          Koala::Facebook::GraphAPI.stub(:batch_calls).and_return(@batch_queue)
+          allow(Koala::Facebook::GraphAPI).to receive(:batch_calls).and_return(@batch_queue)
 
           @args[:method] = "post" # files are always post
         end
@@ -255,7 +255,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_op = Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args)
           file_ids = batch_op.files.find_all {|k, v| v == @uploadable_io}.map {|k, v| k}
           params = batch_op.to_batch_params(nil)
-          params[:attached_files].should == file_ids.join(",")
+          expect(params[:attached_files]).to eq(file_ids.join(","))
         end
       end
     end
@@ -264,33 +264,33 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
   describe "GraphAPI batch interface" do
     it "returns nothing for a batch operation" do
-      Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(200, "[]", {}))
+      allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, "[]", {}))
       @api.batch do |batch_api|
-        batch_api.get_object('me').should be_nil
+        expect(batch_api.get_object('me')).to be_nil
       end
     end
 
     describe "#batch" do
       before :each do
         @fake_response = Koala::HTTPService::Response.new(200, "[]", {})
-        Koala.stub(:make_request).and_return(@fake_response)
+        allow(Koala).to receive(:make_request).and_return(@fake_response)
       end
 
       describe "making the request" do
         context "with no calls" do
           it "does not make any requests if batch_calls is empty" do
-            Koala.should_not_receive(:make_request)
+            expect(Koala).not_to receive(:make_request)
             @api.batch {|batch_api|}
           end
 
           it "returns []" do
-            @api.batch {|batch_api|}.should == []
+            expect(@api.batch {|batch_api|}).to eq([])
           end
         end
 
         it "includes the first operation's access token as the main one in the args" do
           access_token = "foo"
-          Koala.should_receive(:make_request).with(anything, hash_including("access_token" => access_token), anything, anything).and_return(@fake_response)
+          expect(Koala).to receive(:make_request).with(anything, hash_including("access_token" => access_token), anything, anything).and_return(@fake_response)
           Koala::Facebook::API.new(access_token).batch do |batch_api|
             batch_api.get_object('me')
             batch_api.get_object('me', {}, {'access_token' => 'bar'})
@@ -300,12 +300,12 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         it "sets args['batch'] to a json'd map of all the batch params" do
           access_token = "bar"
           op = Koala::Facebook::GraphBatchAPI::BatchOperation.new(:access_token => access_token, :method => :get, :url => "/")
-          op.stub(:to_batch_params).and_return({:a => 2})
-          Koala::Facebook::GraphBatchAPI::BatchOperation.stub(:new).and_return(op)
+          allow(op).to receive(:to_batch_params).and_return({:a => 2})
+          allow(Koala::Facebook::GraphBatchAPI::BatchOperation).to receive(:new).and_return(op)
 
           # two requests should generate two batch operations
           expected = MultiJson.dump([op.to_batch_params(access_token), op.to_batch_params(access_token)])
-          Koala.should_receive(:make_request).with(anything, hash_including("batch" => expected), anything, anything).and_return(@fake_response)
+          expect(Koala).to receive(:make_request).with(anything, hash_including("batch" => expected), anything, anything).and_return(@fake_response)
           Koala::Facebook::API.new(access_token).batch do |batch_api|
             batch_api.get_object('me')
             batch_api.get_object('me')
@@ -319,9 +319,9 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           @key = "file0_0"
           @uploadable_io = double("UploadableIO")
           batch_op = double("Koala Batch Operation", :files => {@key => @uploadable_io}, :to_batch_params => {}, :access_token => "foo")
-          Koala::Facebook::GraphBatchAPI::BatchOperation.stub(:new).and_return(batch_op)
+          allow(Koala::Facebook::GraphBatchAPI::BatchOperation).to receive(:new).and_return(batch_op)
 
-          Koala.should_receive(:make_request).with(anything, hash_including(@key => @uploadable_io), anything, anything).and_return(@fake_response)
+          expect(Koala).to receive(:make_request).with(anything, hash_including(@key => @uploadable_io), anything, anything).and_return(@fake_response)
           Koala::Facebook::API.new("bar").batch do |batch_api|
             batch_api.put_picture("path/to/file", "image/jpeg")
           end
@@ -330,9 +330,9 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         it "preserves operation order" do
           access_token = "bar"
           # two requests should generate two batch operations
-          Koala.should_receive(:make_request) do |url, args, method, options|
+          expect(Koala).to receive(:make_request) do |url, args, method, options|
             # test the batch operations to make sure they appear in the right order
-            (args ||= {})["batch"].should =~ /.*me\/farglebarg.*otheruser\/bababa/
+            expect((args ||= {})["batch"]).to match(/.*me\/farglebarg.*otheruser\/bababa/)
             @fake_response
           end
           Koala::Facebook::API.new(access_token).batch do |batch_api|
@@ -342,14 +342,14 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         end
 
         it "makes a POST request" do
-          Koala.should_receive(:make_request).with(anything, anything, "post", anything).and_return(@fake_response)
+          expect(Koala).to receive(:make_request).with(anything, anything, "post", anything).and_return(@fake_response)
           Koala::Facebook::API.new("foo").batch do |batch_api|
             batch_api.get_object('me')
           end
         end
 
         it "makes a request to /" do
-          Koala.should_receive(:make_request).with("/", anything, anything, anything).and_return(@fake_response)
+          expect(Koala).to receive(:make_request).with("/", anything, anything, anything).and_return(@fake_response)
           Koala::Facebook::API.new("foo").batch do |batch_api|
             batch_api.get_object('me')
           end
@@ -357,7 +357,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
         it "includes any http options specified at the top level" do
           http_options = {"a" => "baz"}
-          Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(http_options)).and_return(@fake_response)
+          expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(http_options)).and_return(@fake_response)
           Koala::Facebook::API.new("foo").batch(http_options) do |batch_api|
             batch_api.get_object('me')
           end
@@ -366,23 +366,23 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
       describe "processing the request" do
         it "returns the result headers as a hash if http_component is headers" do
-          Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(200, '[{"code":203,"headers":[{"name":"Content-Type","value":"text/javascript; charset=UTF-8"}],"body":"{\"id\":\"1234\"}"}]', {}))
+          allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, '[{"code":203,"headers":[{"name":"Content-Type","value":"text/javascript; charset=UTF-8"}],"body":"{\"id\":\"1234\"}"}]', {}))
           result = @api.batch do |batch_api|
             batch_api.get_object(KoalaTest.user1, {}, :http_component => :headers)
           end
-          result[0].should == {"Content-Type" => "text/javascript; charset=UTF-8"}
+          expect(result[0]).to eq({"Content-Type" => "text/javascript; charset=UTF-8"})
         end
 
         describe "if it errors" do
           it "raises an APIError if the response is not 200" do
-            Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(500, "[]", {}))
+            allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(500, "[]", {}))
             expect {
               Koala::Facebook::API.new("foo").batch {|batch_api| batch_api.get_object('me') }
             }.to raise_exception(Koala::Facebook::APIError)
           end
 
           it "raises a BadFacebookResponse if the body is empty" do
-            Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(200, "", {}))
+            allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, "", {}))
             expect {
               Koala::Facebook::API.new("foo").batch {|batch_api| batch_api.get_object('me') }
             }.to raise_exception(Koala::Facebook::BadFacebookResponse)
@@ -390,7 +390,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
           context "with the old style" do
             before :each do
-              Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(400, '{"error_code":190,"error_description":"Error validating access token."}', {}))
+              allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(400, '{"error_code":190,"error_description":"Error validating access token."}', {}))
             end
 
             it "throws an error" do
@@ -403,8 +403,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
               begin
                 Koala::Facebook::API.new("foo").batch {|batch_api| batch_api.get_object('me') }
               rescue Koala::Facebook::APIError => err
-                err.fb_error_code.should == 190
-                err.fb_error_message.should == "Error validating access token."
+                expect(err.fb_error_code).to eq(190)
+                expect(err.fb_error_message).to eq("Error validating access token.")
                 err.http_status == 400
                 err.response_body == '{"error_code":190,"error_description":"Error validating access token."}'
               end
@@ -413,7 +413,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
           context "with the new style" do
             before :each do
-              Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(400, '{"error":{"message":"Request 0 cannot depend on an  unresolved request with  name f. Requests can only depend on preceding requests","type":"GraphBatchException"}}', {}))
+              allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(400, '{"error":{"message":"Request 0 cannot depend on an  unresolved request with  name f. Requests can only depend on preceding requests","type":"GraphBatchException"}}', {}))
             end
 
             it "throws an error" do
@@ -426,8 +426,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
               begin
                 Koala::Facebook::API.new("foo").batch {|batch_api| batch_api.get_object('me') }
               rescue Koala::Facebook::APIError => err
-                err.fb_error_type.should == "GraphBatchException"
-                err.fb_error_message.should == "Request 0 cannot depend on an  unresolved request with  name f. Requests can only depend on preceding requests"
+                expect(err.fb_error_type).to eq("GraphBatchException")
+                expect(err.fb_error_message).to eq("Request 0 cannot depend on an  unresolved request with  name f. Requests can only depend on preceding requests")
                 err.http_status == 400
                 err.response_body == '{"error":{"message":"Request 0 cannot depend on an  unresolved request with  name f. Requests can only depend on preceding requests","type":"GraphBatchException"}}'
               end
@@ -436,11 +436,11 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         end
 
         it "returns the result status if http_component is status" do
-          Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(200, '[{"code":203,"headers":[{"name":"Content-Type","value":"text/javascript; charset=UTF-8"}],"body":"{\"id\":\"1234\"}"}]', {}))
+          allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, '[{"code":203,"headers":[{"name":"Content-Type","value":"text/javascript; charset=UTF-8"}],"body":"{\"id\":\"1234\"}"}]', {}))
           result = @api.batch do |batch_api|
             batch_api.get_object(KoalaTest.user1, {}, :http_component => :status)
           end
-          result[0].should == 203
+          expect(result[0]).to eq(203)
         end
       end
 
@@ -451,7 +451,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         first_count = 20
         second_count = 10
 
-        Koala.stub(:make_request).and_return(@fake_response)
+        allow(Koala).to receive(:make_request).and_return(@fake_response)
 
         thread1 = Thread.new do
           @api.batch do |batch_api|
@@ -470,8 +470,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         thread1.join
         thread2.join
 
-        thread_one_count.should == first_count
-        thread_two_count.should == second_count
+        expect(thread_one_count).to eq(first_count)
+        expect(thread_two_count).to eq(second_count)
       end
     end
   end
@@ -482,8 +482,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_object('me')
         batch_api.get_object(KoalaTest.user1)
       end
-      me['id'].should_not be_nil
-      koppel['id'].should_not be_nil
+      expect(me['id']).not_to be_nil
+      expect(koppel['id']).not_to be_nil
     end
 
     it 'makes mixed calls inside of a batch' do
@@ -491,7 +491,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_object('me')
         batch_api.get_connections('me', 'friends')
       end
-      friends.should be_a(Koala::Facebook::GraphCollection)
+      expect(friends).to be_a(Koala::Facebook::GraphCollection)
     end
 
     it 'turns pageable results into GraphCollections' do
@@ -499,15 +499,15 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_object('me')
         batch_api.get_connections('me', 'friends')
       end
-      me['id'].should_not be_nil
-      friends.should be_an(Array)
+      expect(me['id']).not_to be_nil
+      expect(friends).to be_an(Array)
     end
 
     it 'makes a get_picture call inside of a batch' do
       pictures = @api.batch do |batch_api|
         batch_api.get_picture('me')
       end
-      pictures.first.should =~ /http\:\/\// # works both live & stubbed
+      expect(pictures.first).to match(/http\:\/\//) # works both live & stubbed
     end
 
     it "handles requests for two different tokens" do
@@ -515,8 +515,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_object('me')
         batch_api.get_connections(@app_id, 'insights', {}, {"access_token" => @app_api.access_token})
       end
-      me['id'].should_not be_nil
-      insights.should be_an(Koala::Facebook::GraphCollection)
+      expect(me['id']).not_to be_nil
+      expect(insights).to be_an(Koala::Facebook::GraphCollection)
     end
 
     it "preserves batch-op specific access tokens in GraphCollection returned from batch" do
@@ -531,11 +531,11 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
 
       # The alternate token is returned with the next page parameters
       # The GraphCollection should receive a request for the next_page_params during paging
-      insights.should_receive(:next_page_params).and_return([double("base"), @other_access_token_args.dup])
+      expect(insights).to receive(:next_page_params).and_return([double("base"), @other_access_token_args.dup])
 
       # The alternate access token should pass through to making the request
       # Koala should receive a request during paging using the alternate token
-      Koala.should_receive(:make_request).with(
+      expect(Koala).to receive(:make_request).with(
           anything,
           hash_including(@other_access_token_args.dup),
           anything,
@@ -551,8 +551,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_connection("2", "invalidconnection")
         batch_api.get_object(KoalaTest.user1, {}, {"access_token" => @app_api.access_token})
       end
-      failed_call.should be_a(Koala::Facebook::ClientError)
-      koppel["id"].should_not be_nil
+      expect(failed_call).to be_a(Koala::Facebook::ClientError)
+      expect(koppel["id"]).not_to be_nil
     end
 
     it "handles different request methods" do
@@ -571,8 +571,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
       end
 
       fql_result = result[0]
-      fql_result[0].should be_a(Hash)
-      fql_result[0]["first_name"].should == "Alex"
+      expect(fql_result[0]).to be_a(Hash)
+      expect(fql_result[0]["first_name"]).to eq("Alex")
     end
 
     describe 'with post-processing callback' do
@@ -587,8 +587,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_api.get_object('me', &me_callback)
           batch_api.get_connections('me', 'friends', &friends_callback)
         end
-        me["args"].should include("id" => KoalaTest.user1)
-        friends["args"].first.should include("id" => KoalaTest.user2)
+        expect(me["args"]).to include("id" => KoalaTest.user1)
+        expect(friends["args"].first).to include("id" => KoalaTest.user2)
       end
 
       it 'passes GraphCollections, not raw data' do
@@ -596,14 +596,14 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_api.get_object('me')
           batch_api.get_connections('me', 'friends', &friends_callback)
         end
-        friends["args"].should be_a(Koala::Facebook::API::GraphCollection)
+        expect(friends["args"]).to be_a(Koala::Facebook::API::GraphCollection)
       end
 
       it "returns the result of the callback" do
-        @api.batch do |batch_api|
+        expect(@api.batch do |batch_api|
           batch_api.get_object('me', &me_callback)
           batch_api.get_connections('me', 'friends', &friends_callback)
-        end.map {|r| r["result"]}.should == [me_result, friends_result]
+        end.map {|r| r["result"]}).to eq([me_result, friends_result])
       end
     end
 
@@ -617,7 +617,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         end
 
         @temporary_object_id = result[0]["id"]
-        @temporary_object_id.should_not be_nil
+        expect(@temporary_object_id).not_to be_nil
       end
 
       it "posts binary files with multiple requests" do
@@ -629,8 +629,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_api.put_picture(file)
           batch_api.put_picture(file2, {}, KoalaTest.user1)
         end
-        results[0]["id"].should_not be_nil
-        results[1]["id"].should_not be_nil
+        expect(results[0]["id"]).not_to be_nil
+        expect(results[1]["id"]).not_to be_nil
       end
     end
 
@@ -641,8 +641,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_api.get_objects("{result=get-friends:$.data.*.id}")
         end
 
-        results[0].should be_nil
-        results[1].should be_an(Hash)
+        expect(results[0]).to be_nil
+        expect(results[1]).to be_an(Hash)
       end
 
       it "allows you create relationships between requests with omit_response_on_success" do
@@ -651,8 +651,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_api.get_objects("{result=get-friends:$.data.*.id}")
         end
 
-        results[0].should be_an(Array)
-        results[1].should be_an(Hash)
+        expect(results[0]).to be_an(Array)
+        expect(results[1]).to be_an(Hash)
       end
 
       it "allows you to create dependencies" do
@@ -661,8 +661,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_api.get_object(KoalaTest.user1, {}, :batch_args => {:depends_on => "getme"})
         end
 
-        me.should be_nil # gotcha!  it's omitted because it's a successfully-executed dependency
-        koppel["id"].should_not be_nil
+        expect(me).to be_nil # gotcha!  it's omitted because it's a successfully-executed dependency
+        expect(koppel["id"]).not_to be_nil
       end
 
       it "properly handles dependencies that fail" do
@@ -671,8 +671,8 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           batch_api.get_object(KoalaTest.user1, {}, :batch_args => {:depends_on => "getdata"})
         end
 
-        failed_call.should be_a(Koala::Facebook::ClientError)
-        koppel.should be_nil
+        expect(failed_call).to be_a(Koala::Facebook::ClientError)
+        expect(koppel).to be_nil
       end
 
       it "throws an error for badly-constructed request relationships" do

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -17,21 +17,21 @@ describe 'Koala::Facebook::GraphAPIMethods' do
     # and the other methods which do some post-processing locally
     context '#get_object' do
       it 'returns result of block' do
-        @api.stub(:api).and_return(double("other results"))
-        @api.get_object('koppel', &post_processing)["result"].should == result
+        allow(@api).to receive(:api).and_return(double("other results"))
+        expect(@api.get_object('koppel', &post_processing)["result"]).to eq(result)
       end
     end
 
     context '#get_picture' do
       it 'returns result of block' do
-        @api.stub(:api).and_return("Location" => double("other result"))
-        @api.get_picture('lukeshepard', &post_processing)["result"].should == result
+        allow(@api).to receive(:api).and_return("Location" => double("other result"))
+        expect(@api.get_picture('lukeshepard', &post_processing)["result"]).to eq(result)
       end
     end
 
     context '#fql_multiquery' do
       before do
-        @api.should_receive(:get_object).and_return([
+        expect(@api).to receive(:get_object).and_return([
           {"name" => "query1", "fql_result_set" => [{"id" => 123}]},
           {"name" => "query2", "fql_result_set" => ["id" => 456]}
         ])
@@ -43,18 +43,18 @@ describe 'Koala::Facebook::GraphAPIMethods' do
           'query2' => [{'id' => 456}]
         }
         response = @api.fql_multiquery({}, &post_processing)
-        response["args"].should == resolved_result
-        response["result"].should == result
+        expect(response["args"]).to eq(resolved_result)
+        expect(response["result"]).to eq(result)
       end
     end
 
     context '#get_page_access_token' do
       it 'returns result of block' do
         token = Koala::MockHTTPService::APP_ACCESS_TOKEN
-        @api.stub(:api).and_return("access_token" => token)
+        allow(@api).to receive(:api).and_return("access_token" => token)
         response = @api.get_page_access_token('facebook', &post_processing)
-        response["args"].should == token
-        response["result"].should == result
+        expect(response["args"]).to eq(token)
+        expect(response["result"]).to eq(result)
       end
     end
   end

--- a/spec/cases/graph_collection_spec.rb
+++ b/spec/cases/graph_collection_spec.rb
@@ -13,32 +13,32 @@ describe Koala::Facebook::GraphCollection do
   end
 
   it "subclasses Array" do
-    Koala::Facebook::GraphCollection.ancestors.should include(Array)
+    expect(Koala::Facebook::GraphCollection.ancestors).to include(Array)
   end
 
   it "creates an array-like object" do
-    Koala::Facebook::GraphCollection.new(@result, @api).should be_an(Array)
+    expect(Koala::Facebook::GraphCollection.new(@result, @api)).to be_an(Array)
   end
 
   it "contains the result data" do
-    @result["data"].each_with_index {|r, i| @collection[i].should == r}
+    @result["data"].each_with_index {|r, i| expect(@collection[i]).to eq(r)}
   end
 
   it "has a read-only paging attribute" do
-    @collection.methods.map(&:to_sym).should include(:paging)
-    @collection.methods.map(&:to_sym).should_not include(:paging=)
+    expect(@collection.methods.map(&:to_sym)).to include(:paging)
+    expect(@collection.methods.map(&:to_sym)).not_to include(:paging=)
   end
 
   it "sets paging to results['paging']" do
-    @collection.paging.should == @result["paging"]
+    expect(@collection.paging).to eq(@result["paging"])
   end
 
   it "sets raw_response to the original results" do
-    @collection.raw_response.should == @result
+    expect(@collection.raw_response).to eq(@result)
   end
 
   it "sets the API to the provided API" do
-    @collection.api.should == @api
+    expect(@collection.api).to eq(@api)
   end
 
   describe "when getting a whole page" do
@@ -53,24 +53,24 @@ describe Koala::Facebook::GraphCollection do
     end
 
     it "should return the previous page of results" do
-      @collection.should_receive(:previous_page_params).and_return([@base, @args])
-      @api.should_receive(:api).with(@base, @args, anything, anything).and_return(@second_page)
-      Koala::Facebook::GraphCollection.should_receive(:new).with(@second_page, @api).and_return(@page_of_results)
-      @collection.previous_page.should == @page_of_results
+      expect(@collection).to receive(:previous_page_params).and_return([@base, @args])
+      expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(@second_page)
+      expect(Koala::Facebook::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
+      expect(@collection.previous_page).to eq(@page_of_results)
     end
 
     it "should return the next page of results" do
-      @collection.should_receive(:next_page_params).and_return([@base, @args])
-      @api.should_receive(:api).with(@base, @args, anything, anything).and_return(@second_page)
-      Koala::Facebook::GraphCollection.should_receive(:new).with(@second_page, @api).and_return(@page_of_results)
+      expect(@collection).to receive(:next_page_params).and_return([@base, @args])
+      expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(@second_page)
+      expect(Koala::Facebook::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
 
-      @collection.next_page.should == @page_of_results
+      expect(@collection.next_page).to eq(@page_of_results)
     end
 
     it "should return nil it there are no other pages" do
       %w{next previous}.each do |this|
-        @collection.should_receive("#{this}_page_params".to_sym).and_return(nil)
-        @collection.send("#{this}_page").should == nil
+        expect(@collection).to receive("#{this}_page_params".to_sym).and_return(nil)
+        expect(@collection.send("#{this}_page")).to eq(nil)
       end
     end
   end
@@ -79,38 +79,38 @@ describe Koala::Facebook::GraphCollection do
     describe "#parse_page_url" do
       it "should pass the url to the class method" do
         url = double("url")
-        Koala::Facebook::GraphCollection.should_receive(:parse_page_url).with(url)
+        expect(Koala::Facebook::GraphCollection).to receive(:parse_page_url).with(url)
         @collection.parse_page_url(url)
       end
 
       it "should return the result of the class method" do
         parsed_content = double("parsed_content")
-        Koala::Facebook::GraphCollection.stub(:parse_page_url).and_return(parsed_content)
-        @collection.parse_page_url(double("url")).should == parsed_content
+        allow(Koala::Facebook::GraphCollection).to receive(:parse_page_url).and_return(parsed_content)
+        expect(@collection.parse_page_url(double("url"))).to eq(parsed_content)
       end
     end
 
     describe ".parse_page_url" do
       it "should return the base as the first array entry" do
         base = "url_path"
-        Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/#{base}?anything").first.should == base
+        expect(Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/#{base}?anything").first).to eq(base)
       end
 
       it "should return the arguments as a hash as the last array entry" do
         args_hash = {"one" => "val_one", "two" => "val_two"}
-        Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/anything?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}").last.should == args_hash
+        expect(Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/anything?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}").last).to eq(args_hash)
       end
 
       it "works with non-.com addresses" do
         base = "url_path"
         args_hash = {"one" => "val_one", "two" => "val_two"}
-        Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/#{base}?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}").should == [base, args_hash]
+        expect(Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/#{base}?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}")).to eq([base, args_hash])
       end
 
       it "works with addresses with irregular characters" do
         access_token = "appid123a|fdcba"
         base, args_hash = Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/foo?token=#{access_token}")
-        args_hash["token"].should == access_token
+        expect(args_hash["token"]).to eq(access_token)
       end
     end
   end
@@ -118,29 +118,29 @@ describe Koala::Facebook::GraphCollection do
   describe ".evaluate" do
     it "returns the original result if it's provided a non-hash result" do
       result = []
-      Koala::Facebook::GraphCollection.evaluate(result, @api).should == result
+      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns the original result if it's provided a nil result" do
       result = nil
-      Koala::Facebook::GraphCollection.evaluate(result, @api).should == result
+      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns the original result if the result doesn't have a data key" do
       result = {"paging" => {}}
-      Koala::Facebook::GraphCollection.evaluate(result, @api).should == result
+      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns the original result if the result's data key isn't an array" do
       result = {"data" => {}, "paging" => {}}
-      Koala::Facebook::GraphCollection.evaluate(result, @api).should == result
+      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns a new GraphCollection of the result if it has an array data key and a paging key" do
       result = {"data" => [], "paging" => {}}
       expected = :foo
-      Koala::Facebook::GraphCollection.should_receive(:new).with(result, @api).and_return(expected)
-      Koala::Facebook::GraphCollection.evaluate(result, @api).should == expected
+      expect(Koala::Facebook::GraphCollection).to receive(:new).with(result, @api).and_return(expected)
+      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(expected)
     end
   end
 
@@ -148,12 +148,12 @@ describe Koala::Facebook::GraphCollection do
     let(:paging){ {"next" => "http://example.com/?a=2&b=3"} }
 
     it "should get next page" do
-      @api.should_receive(:get_page).with(["", {"a" => "2", "b" => "3"}])
+      expect(@api).to receive(:get_page).with(["", {"a" => "2", "b" => "3"}])
       @collection.next_page
     end
 
     it "should get next page with extra parameters" do
-      @api.should_receive(:get_page).with(["", {"a" => "2", "b" => "3", "c" => "4"}])
+      expect(@api).to receive(:get_page).with(["", {"a" => "2", "b" => "3", "c" => "4"}])
       @collection.next_page("c" => "4")
     end
   end
@@ -162,12 +162,12 @@ describe Koala::Facebook::GraphCollection do
     let(:paging){ {"previous" => "http://example.com/?a=2&b=3"} }
 
     it "should get previous page" do
-      @api.should_receive(:get_page).with(["", {"a" => "2", "b" => "3"}])
+      expect(@api).to receive(:get_page).with(["", {"a" => "2", "b" => "3"}])
       @collection.previous_page
     end
 
     it "should get previous page with extra parameters" do
-      @api.should_receive(:get_page).with(["", {"a" => "2", "b" => "3", "c" => "4"}])
+      expect(@api).to receive(:get_page).with(["", {"a" => "2", "b" => "3", "c" => "4"}])
       @collection.previous_page("c" => "4")
     end
   end

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -2,45 +2,45 @@ require 'spec_helper'
 
 describe Koala::HTTPService do
   it "has a faraday_middleware accessor" do
-    Koala::HTTPService.methods.map(&:to_sym).should include(:faraday_middleware)
-    Koala::HTTPService.methods.map(&:to_sym).should include(:faraday_middleware=)
+    expect(Koala::HTTPService.methods.map(&:to_sym)).to include(:faraday_middleware)
+    expect(Koala::HTTPService.methods.map(&:to_sym)).to include(:faraday_middleware=)
   end
 
   it "has an http_options accessor" do
-    Koala::HTTPService.should respond_to(:http_options)
-    Koala::HTTPService.should respond_to(:http_options=)
+    expect(Koala::HTTPService).to respond_to(:http_options)
+    expect(Koala::HTTPService).to respond_to(:http_options=)
   end
 
   it "sets http_options to {} by default" do
-    Koala::HTTPService.http_options.should == {}
+    expect(Koala::HTTPService.http_options).to eq({})
   end
 
   describe "DEFAULT_MIDDLEWARE" do
     before :each do
       @builder = double("Faraday connection builder")
-      @builder.stub(:request)
-      @builder.stub(:adapter)
-      @builder.stub(:use)
+      allow(@builder).to receive(:request)
+      allow(@builder).to receive(:adapter)
+      allow(@builder).to receive(:use)
     end
 
     it "is defined" do
-      Koala::HTTPService.const_defined?("DEFAULT_MIDDLEWARE").should be true
+      expect(Koala::HTTPService.const_defined?("DEFAULT_MIDDLEWARE")).to be true
     end
 
     it "adds multipart" do
-      @builder.should_receive(:use).with(Koala::HTTPService::MultipartRequest)
+      expect(@builder).to receive(:use).with(Koala::HTTPService::MultipartRequest)
       Koala::HTTPService::DEFAULT_MIDDLEWARE.call(@builder)
     end
 
     it "adds url_encoded" do
-      @builder.should_receive(:request).with(:url_encoded)
+      expect(@builder).to receive(:request).with(:url_encoded)
       Koala::HTTPService::DEFAULT_MIDDLEWARE.call(@builder)
     end
 
     it "uses the default adapter" do
       adapter = :testing_now
-      Faraday.stub(:default_adapter).and_return(adapter)
-      @builder.should_receive(:adapter).with(adapter)
+      allow(Faraday).to receive(:default_adapter).and_return(adapter)
+      expect(@builder).to receive(:adapter).with(adapter)
       Koala::HTTPService::DEFAULT_MIDDLEWARE.call(@builder)
     end
   end
@@ -49,39 +49,39 @@ describe Koala::HTTPService do
     let(:defaults) { Koala::HTTPService::DEFAULT_SERVERS }
 
     it "defines the graph server" do
-      defaults[:graph_server].should == "graph.facebook.com"
+      expect(defaults[:graph_server]).to eq("graph.facebook.com")
     end
 
     it "defines the rest server" do
-      defaults[:rest_server].should == "api.facebook.com"
+      expect(defaults[:rest_server]).to eq("api.facebook.com")
     end
 
     it "defines the dialog host" do
-      defaults[:dialog_host].should == "www.facebook.com"
+      expect(defaults[:dialog_host]).to eq("www.facebook.com")
     end
 
     it "defines the path replacement regular expression" do
-      defaults[:host_path_matcher].should == /\.facebook/
+      expect(defaults[:host_path_matcher]).to eq(/\.facebook/)
     end
 
     it "defines the video server replacement for uploads" do
-      defaults[:video_replace].should == "-video.facebook"
+      expect(defaults[:video_replace]).to eq("-video.facebook")
     end
 
     it "defines the beta tier replacement" do
-      defaults[:beta_replace].should == ".beta.facebook"
+      expect(defaults[:beta_replace]).to eq(".beta.facebook")
     end
   end
 
   describe "server" do
     describe "with no options" do
       it "returns the REST server if options[:rest_api]" do
-        Koala::HTTPService.server(:rest_api => true).should =~ Regexp.new(Koala.config.rest_server)
+        expect(Koala::HTTPService.server(:rest_api => true)).to match(Regexp.new(Koala.config.rest_server))
       end
 
       it "returns the graph server if !options[:rest_api]" do
-        Koala::HTTPService.server(:rest_api => false).should =~ Regexp.new(Koala.config.graph_server)
-        Koala::HTTPService.server({}).should =~ Regexp.new(Koala.config.graph_server)
+        expect(Koala::HTTPService.server(:rest_api => false)).to match(Regexp.new(Koala.config.graph_server))
+        expect(Koala::HTTPService.server({})).to match(Regexp.new(Koala.config.graph_server))
       end
     end
 
@@ -92,12 +92,12 @@ describe Koala::HTTPService do
 
       it "returns the beta REST server if options[:rest_api]" do
         server = Koala::HTTPService.server(@options.merge(:rest_api => true))
-        server.should =~ Regexp.new(Koala.config.rest_server.gsub(/\.facebook/, ".beta.facebook"))
+        expect(server).to match(Regexp.new(Koala.config.rest_server.gsub(/\.facebook/, ".beta.facebook")))
       end
 
       it "returns the beta rest server if !options[:rest_api]" do
         server = Koala::HTTPService.server(@options)
-        server.should =~ Regexp.new(Koala.config.graph_server.gsub(/\.facebook/, ".beta.facebook"))
+        expect(server).to match(Regexp.new(Koala.config.graph_server.gsub(/\.facebook/, ".beta.facebook")))
       end
     end
 
@@ -108,26 +108,26 @@ describe Koala::HTTPService do
 
       it "returns the REST video server if options[:rest_api]" do
         server = Koala::HTTPService.server(@options.merge(:rest_api => true))
-        server.should =~ Regexp.new(Koala.config.rest_server.gsub(/\.facebook/, "-video.facebook"))
+        expect(server).to match(Regexp.new(Koala.config.rest_server.gsub(/\.facebook/, "-video.facebook")))
       end
 
       it "returns the graph video server if !options[:rest_api]" do
         server = Koala::HTTPService.server(@options)
-        server.should =~ Regexp.new(Koala.config.graph_server.gsub(/\.facebook/, "-video.facebook"))
+        expect(server).to match(Regexp.new(Koala.config.graph_server.gsub(/\.facebook/, "-video.facebook")))
       end
     end
   end
 
   describe ".encode_params" do
     it "returns an empty string if param_hash evaluates to false" do
-      Koala::HTTPService.encode_params(nil).should == ''
+      expect(Koala::HTTPService.encode_params(nil)).to eq('')
     end
 
     it "converts values to JSON if the value is not a String" do
       val = 'json_value'
       not_a_string = 'not_a_string'
-      not_a_string.stub(:is_a?).and_return(false)
-      MultiJson.should_receive(:dump).with(not_a_string).and_return(val)
+      allow(not_a_string).to receive(:is_a?).and_return(false)
+      expect(MultiJson).to receive(:dump).with(not_a_string).and_return(val)
 
       string = "hi"
 
@@ -137,9 +137,9 @@ describe Koala::HTTPService do
       }
 
       result = Koala::HTTPService.encode_params(args)
-      result.split('&').find do |key_and_val|
+      expect(result.split('&').find do |key_and_val|
         key_and_val.match("#{not_a_string}=#{val}")
-      end.should be_truthy
+      end).to be_truthy
     end
 
     it "escapes all values" do
@@ -148,7 +148,7 @@ describe Koala::HTTPService do
       result = Koala::HTTPService.encode_params(args)
       result.split('&').each do |key_val|
         key, val = key_val.split('=')
-        val.should == CGI.escape(args[key])
+        expect(val).to eq(CGI.escape(args[key]))
       end
     end
 
@@ -156,7 +156,7 @@ describe Koala::HTTPService do
       args = {:b => '2', 'a' => '1'}
 
       result = Koala::HTTPService.encode_params(args)
-      result.split('&').map{|key_val| key_val.split('=')[0]}.should == ['a', 'b']
+      expect(result.split('&').map{|key_val| key_val.split('=')[0]}).to eq(['a', 'b'])
     end
 
     it "converts all keys to Strings" do
@@ -165,7 +165,7 @@ describe Koala::HTTPService do
       result = Koala::HTTPService.encode_params(args)
       result.split('&').each do |key_val|
         key, val = key_val.split('=')
-        key.should == args.find{|key_val_arr| key_val_arr.last == val}.first.to_s
+        expect(key).to eq(args.find{|key_val_arr| key_val_arr.last == val}.first.to_s)
       end
     end
   end
@@ -178,103 +178,103 @@ describe Koala::HTTPService do
       @mock_http_response = double("Faraday Response", :status => 200, :headers => @mock_headers_hash, :body => @mock_body)
 
       @mock_connection = double("Faraday connection")
-      @mock_connection.stub(:get).and_return(@mock_http_response)
-      @mock_connection.stub(:post).and_return(@mock_http_response)
-      Faraday.stub(:new).and_return(@mock_connection)
+      allow(@mock_connection).to receive(:get).and_return(@mock_http_response)
+      allow(@mock_connection).to receive(:post).and_return(@mock_http_response)
+      allow(Faraday).to receive(:new).and_return(@mock_connection)
     end
 
     describe "creating the Faraday connection" do
       it "creates a Faraday connection using the server" do
         server = "foo"
-        Koala::HTTPService.stub(:server).and_return(server)
-        Faraday.should_receive(:new).with(server, anything).and_return(@mock_connection)
+        allow(Koala::HTTPService).to receive(:server).and_return(server)
+        expect(Faraday).to receive(:new).with(server, anything).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {}, "anything")
       end
 
       it "merges Koala::HTTPService.http_options into the request params" do
         http_options = {:proxy => "http://user:password@example.org/", :request => { :timeout => 3 }}
         Koala::HTTPService.http_options = http_options
-        Faraday.should_receive(:new).with(anything, hash_including(http_options)).and_return(@mock_connection)
+        expect(Faraday).to receive(:new).with(anything, hash_including(http_options)).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {}, "get")
       end
 
       it "does not merge invalid Faraday options from Koala::HTTPService.http_options into the request params" do
         http_options = {:invalid => "fake param"}
         Koala::HTTPService.http_options = http_options
-        Faraday.should_receive(:new).with(anything, hash_not_including(http_options)).and_return(@mock_connection)
+        expect(Faraday).to receive(:new).with(anything, hash_not_including(http_options)).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {}, "get")
       end
 
       it "merges any provided options into the request params" do
         options = {:proxy => "http://user:password@example.org/", :request => { :timeout => 3 }}
-        Faraday.should_receive(:new).with(anything, hash_including(options)).and_return(@mock_connection)
+        expect(Faraday).to receive(:new).with(anything, hash_including(options)).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {}, "get", options)
       end
 
       it "overrides Koala::HTTPService.http_options with any provided options for the request params" do
         options = {:proxy => "http://user:password@proxy.org/", :request => { :timeout => 10 }}
         http_options = {:proxy => "http://user:password@example.org/", :request => { :timeout => 3 }}
-        Koala::HTTPService.stub(:http_options).and_return(http_options)
+        allow(Koala::HTTPService).to receive(:http_options).and_return(http_options)
 
-        Faraday.should_receive(:new).with(anything, hash_including(http_options.merge(options))).and_return(@mock_connection)
+        expect(Faraday).to receive(:new).with(anything, hash_including(http_options.merge(options))).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {}, "get", options)
       end
 
       it "forces use_ssl to true if an access token is present" do
         options = {:use_ssl => false}
-        Koala::HTTPService.stub(:http_options).and_return(:use_ssl => false)
-        Faraday.should_receive(:new).with(anything, hash_including(:ssl => {:verify => true})).and_return(@mock_connection)
+        allow(Koala::HTTPService).to receive(:http_options).and_return(:use_ssl => false)
+        expect(Faraday).to receive(:new).with(anything, hash_including(:ssl => {:verify => true})).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {"access_token" => "foo"}, "get", options)
       end
 
       it "defaults verify to true if use_ssl is true" do
-        Faraday.should_receive(:new).with(anything, hash_including(:ssl => {:verify => true})).and_return(@mock_connection)
+        expect(Faraday).to receive(:new).with(anything, hash_including(:ssl => {:verify => true})).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {"access_token" => "foo"}, "get")
       end
 
       it "allows you to set other verify modes if you really want" do
         options = {:ssl => {:verify => :foo}}
-        Faraday.should_receive(:new).with(anything, hash_including(options)).and_return(@mock_connection)
+        expect(Faraday).to receive(:new).with(anything, hash_including(options)).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {"access_token" => "foo"}, "get", options)
       end
 
       it "calls server with the composite options" do
         options = {:a => 2, :c => "3"}
         http_options = {:a => :a}
-        Koala::HTTPService.stub(:http_options).and_return(http_options)
-        Koala::HTTPService.should_receive(:server).with(hash_including(http_options.merge(options))).and_return("foo")
+        allow(Koala::HTTPService).to receive(:http_options).and_return(http_options)
+        expect(Koala::HTTPService).to receive(:server).with(hash_including(http_options.merge(options))).and_return("foo")
         Koala::HTTPService.make_request("anything", {}, "get", options)
       end
 
       it "uses the default builder block if HTTPService.faraday_middleware block is not defined" do
         block = Proc.new {}
         stub_const("Koala::HTTPService::DEFAULT_MIDDLEWARE", block)
-        Koala::HTTPService.stub(:faraday_middleware).and_return(nil)
-        Faraday.should_receive(:new).with(anything, anything, &block).and_return(@mock_connection)
+        allow(Koala::HTTPService).to receive(:faraday_middleware).and_return(nil)
+        expect(Faraday).to receive(:new).with(anything, anything, &block).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {}, "get")
       end
 
       it "uses the defined HTTPService.faraday_middleware block if defined" do
         block = Proc.new { }
-        Koala::HTTPService.should_receive(:faraday_middleware).and_return(block)
-        Faraday.should_receive(:new).with(anything, anything, &block).and_return(@mock_connection)
+        expect(Koala::HTTPService).to receive(:faraday_middleware).and_return(block)
+        expect(Faraday).to receive(:new).with(anything, anything, &block).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", {}, "get")
       end
     end
 
     it "makes a POST request if the verb isn't get" do
-      @mock_connection.should_receive(:post).and_return(@mock_http_response)
+      expect(@mock_connection).to receive(:post).and_return(@mock_http_response)
       Koala::HTTPService.make_request("anything", {}, "anything")
     end
 
     it "includes the verb in the body if the verb isn't get" do
       verb = "eat"
-      @mock_connection.should_receive(:post).with(anything, hash_including("method" => verb)).and_return(@mock_http_response)
+      expect(@mock_connection).to receive(:post).with(anything, hash_including("method" => verb)).and_return(@mock_http_response)
       Koala::HTTPService.make_request("anything", {}, verb)
     end
 
     it "makes a GET request if the verb is get" do
-      @mock_connection.should_receive(:get).and_return(@mock_http_response)
+      expect(@mock_connection).to receive(:get).and_return(@mock_http_response)
       Koala::HTTPService.make_request("anything", {}, "get")
     end
 
@@ -282,27 +282,27 @@ describe Koala::HTTPService do
       it "submits the arguments in the body" do
         # technically this is done for all requests, but you don't send GET requests with files
         args = {"a" => :b, "c" => 3}
-        Faraday.should_receive(:new).with(anything, hash_including(:params => args)).and_return(@mock_connection)
+        expect(Faraday).to receive(:new).with(anything, hash_including(:params => args)).and_return(@mock_connection)
         Koala::HTTPService.make_request("anything", args, "get")
       end
 
       it "submits nothing to the body" do
         # technically this is done for all requests, but you don't send GET requests with files
         args = {"a" => :b, "c" => 3}
-        @mock_connection.should_receive(:get).with(anything, {}).and_return(@mock_http_response)
+        expect(@mock_connection).to receive(:get).with(anything, {}).and_return(@mock_http_response)
         Koala::HTTPService.make_request("anything", args, "get")
       end
 
       it "logs verb, url and params to debug" do
         args = {"a" => :b, "c" => 3}
         log_message_stem = "GET: anything params: "
-        Koala::Utils.logger.should_receive(:debug) do |log_message|
+        expect(Koala::Utils.logger).to receive(:debug) do |log_message|
           # unordered hashes are a bane
           # Ruby in 1.8 modes tends to return different hash orderings,
           # which makes checking the content of the stringified hash hard
           # it's enough just to ensure that there's hash content in the string, I think
-          log_message.should include(log_message_stem)
-          log_message.match(/\{.*\}/).should_not be_nil
+          expect(log_message).to include(log_message_stem)
+          expect(log_message.match(/\{.*\}/)).not_to be_nil
         end
 
         Koala::HTTPService.make_request("anything", args, "get")
@@ -313,7 +313,7 @@ describe Koala::HTTPService do
       it "submits the arguments in the body" do
         # technically this is done for all requests, but you don't send GET requests with files
         args = {"a" => :b, "c" => 3}
-        @mock_connection.should_receive(:post).with(anything, hash_including(args)).and_return(@mock_http_response)
+        expect(@mock_connection).to receive(:post).with(anything, hash_including(args)).and_return(@mock_http_response)
         Koala::HTTPService.make_request("anything", args, "post")
       end
 
@@ -321,21 +321,21 @@ describe Koala::HTTPService do
         # technically this is done for all requests, but you don't send GET requests with files
         upload_io = double("UploadIO")
         u = Koala::UploadableIO.new("/path/to/stuff", "img/jpg")
-        u.stub(:to_upload_io).and_return(upload_io)
-        @mock_connection.should_receive(:post).with(anything, hash_including("source" => upload_io)).and_return(@mock_http_response)
+        allow(u).to receive(:to_upload_io).and_return(upload_io)
+        expect(@mock_connection).to receive(:post).with(anything, hash_including("source" => upload_io)).and_return(@mock_http_response)
         Koala::HTTPService.make_request("anything", {:source => u}, "post")
       end
 
       it "logs verb, url and params to debug" do
         args = {"a" => :b, "c" => 3}
         log_message_stem = "POST: anything params: "
-        Koala::Utils.logger.should_receive(:debug) do |log_message|
+        expect(Koala::Utils.logger).to receive(:debug) do |log_message|
           # unordered hashes are a bane
           # Ruby in 1.8 modes tends to return different hash orderings,
           # which makes checking the content of the stringified hash hard
           # it's enough just to ensure that there's hash content in the string, I think
-          log_message.should include(log_message_stem)
-          log_message.match(/\{.*\}/).should_not be_nil
+          expect(log_message).to include(log_message_stem)
+          expect(log_message.match(/\{.*\}/)).not_to be_nil
         end
         Koala::HTTPService.make_request("anything", args, "post")
       end
@@ -344,7 +344,7 @@ describe Koala::HTTPService do
 
   describe "deprecated options" do
     before :each do
-      Koala::HTTPService.stub(:http_options).and_return({})
+      allow(Koala::HTTPService).to receive(:http_options).and_return({})
       @service = Koala.http_service
     end
 
@@ -362,11 +362,11 @@ describe Koala::HTTPService do
           it "reads http_options[:#{parameter}]" do
             value = "foo"
             Koala::HTTPService.http_options[parameter] = value
-            Koala::HTTPService.send(deprecated_method).should == value
+            expect(Koala::HTTPService.send(deprecated_method)).to eq(value)
           end
 
           it "generates a deprecation warning" do
-            Koala::Utils.should_receive(:deprecate)
+            expect(Koala::Utils).to receive(:deprecate)
             Koala::HTTPService.send(deprecated_method)
           end
         end
@@ -376,11 +376,11 @@ describe Koala::HTTPService do
             Koala::HTTPService.http_options[parameter] = nil
             value = "foo"
             Koala::HTTPService.send(:"#{deprecated_method}=", value)
-            Koala::HTTPService.http_options[parameter].should == value
+            expect(Koala::HTTPService.http_options[parameter]).to eq(value)
           end
 
           it "generates a deprecation warning" do
-            Koala::Utils.should_receive(:deprecate)
+            expect(Koala::Utils).to receive(:deprecate)
             Koala::HTTPService.send(:"#{deprecated_method}=", 2)
           end
         end
@@ -394,15 +394,15 @@ describe Koala::HTTPService do
           it "reads http_options[:ssl][:#{deprecated_method}] if http_options[:ssl]" do
             value = "foo"
             Koala::HTTPService.http_options[:ssl] = {deprecated_method => value}
-            Koala::HTTPService.send(deprecated_method).should == value
+            expect(Koala::HTTPService.send(deprecated_method)).to eq(value)
           end
 
           it "returns nil if http_options[:ssl] is not defined" do
-            Koala::HTTPService.send(deprecated_method).should be_nil
+            expect(Koala::HTTPService.send(deprecated_method)).to be_nil
           end
 
           it "generates a deprecation warning" do
-            Koala::Utils.should_receive(:deprecate)
+            expect(Koala::Utils).to receive(:deprecate)
             Koala::HTTPService.send(deprecated_method)
           end
         end
@@ -412,25 +412,25 @@ describe Koala::HTTPService do
             Koala::HTTPService.http_options[:ssl] = nil
             value = "foo"
             Koala::HTTPService.send(:"#{deprecated_method}=", value)
-            Koala::HTTPService.http_options[:ssl].should
+            expect(Koala::HTTPService.http_options[:ssl]).to be_a(Hash)
           end
 
           it "writes to http_options[:ssl][:#{deprecated_method}]" do
             value = "foo"
             Koala::HTTPService.send(:"#{deprecated_method}=", value)
-            Koala::HTTPService.http_options[:ssl].should
-            Koala::HTTPService.http_options[:ssl][deprecated_method].should == value
+            expect(Koala::HTTPService.http_options[:ssl]).to be_a(Hash)
+            expect(Koala::HTTPService.http_options[:ssl][deprecated_method]).to eq(value)
           end
 
           it "does not redefine http_options[:ssl] if already defined" do
             hash = {:a => 2}
             Koala::HTTPService.http_options[:ssl] = hash
             Koala::HTTPService.send(:"#{deprecated_method}=", 3)
-            Koala::HTTPService.http_options[:ssl].should include(hash)
+            expect(Koala::HTTPService.http_options[:ssl]).to include(hash)
           end
 
           it "generates a deprecation warning" do
-            Koala::Utils.should_receive(:deprecate)
+            expect(Koala::Utils).to receive(:deprecate)
             Koala::HTTPService.send(:"#{deprecated_method}=", 2)
           end
         end
@@ -445,21 +445,21 @@ describe Koala::HTTPService do
         @mock_http_response = double("Faraday Response", :status => 200, :headers => @mock_headers_hash, :body => @mock_body)
 
         @mock_connection = double("Faraday connection")
-        @mock_connection.stub(:get).and_return(@mock_http_response)
-        @mock_connection.stub(:post).and_return(@mock_http_response)
-        Faraday.stub(:new).and_return(@mock_connection)
+        allow(@mock_connection).to receive(:get).and_return(@mock_http_response)
+        allow(@mock_connection).to receive(:post).and_return(@mock_http_response)
+        allow(Faraday).to receive(:new).and_return(@mock_connection)
       end
 
       describe ":typhoeus_options" do
         it "merges any typhoeus_options into options" do
           typhoeus_options = {:proxy => "http://user:password@example.org/" }
-          Faraday.should_receive(:new).with(anything, hash_including(typhoeus_options)).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_including(typhoeus_options)).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :typhoeus_options => typhoeus_options)
         end
 
         it "deletes the typhoeus_options key" do
           typhoeus_options = {:proxy => "http://user:password@example.org/" }
-          Faraday.should_receive(:new).with(anything, hash_not_including(:typhoeus_options => typhoeus_options)).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_not_including(:typhoeus_options => typhoeus_options)).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :typhoeus_options => typhoeus_options)
         end
       end
@@ -467,13 +467,13 @@ describe Koala::HTTPService do
       describe ":ca_path" do
         it "sets any ca_path into options[:ssl]" do
           ca_path = :foo
-          Faraday.should_receive(:new).with(anything, hash_including(:ssl => hash_including(:ca_path => ca_path))).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_including(:ssl => hash_including(:ca_path => ca_path))).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :ca_path => ca_path)
         end
 
         it "deletes the ca_path key" do
           ca_path = :foo
-          Faraday.should_receive(:new).with(anything, hash_not_including(:ca_path => ca_path)).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_not_including(:ca_path => ca_path)).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :ca_path => ca_path)
         end
       end
@@ -481,13 +481,13 @@ describe Koala::HTTPService do
       describe ":ca_file" do
         it "sets any ca_file into options[:ssl]" do
           ca_file = :foo
-          Faraday.should_receive(:new).with(anything, hash_including(:ssl => hash_including(:ca_file => ca_file))).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_including(:ssl => hash_including(:ca_file => ca_file))).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :ca_file => ca_file)
         end
 
         it "deletes the ca_file key" do
           ca_file = :foo
-          Faraday.should_receive(:new).with(anything, hash_not_including(:ca_file => ca_file)).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_not_including(:ca_file => ca_file)).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :ca_file => ca_file)
         end
       end
@@ -495,13 +495,13 @@ describe Koala::HTTPService do
       describe ":verify_mode" do
         it "sets any verify_mode into options[:ssl]" do
           verify_mode = :foo
-          Faraday.should_receive(:new).with(anything, hash_including(:ssl => hash_including(:verify_mode => verify_mode))).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_including(:ssl => hash_including(:verify_mode => verify_mode))).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :verify_mode => verify_mode)
         end
 
         it "deletes the verify_mode key" do
           verify_mode = :foo
-          Faraday.should_receive(:new).with(anything, hash_not_including(:verify_mode => verify_mode)).and_return(@mock_connection)
+          expect(Faraday).to receive(:new).with(anything, hash_not_including(:verify_mode => verify_mode)).and_return(@mock_connection)
           Koala::HTTPService.make_request("anything", {}, "get", :verify_mode => verify_mode)
         end
       end

--- a/spec/cases/koala_spec.rb
+++ b/spec/cases/koala_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Koala do
   it "has an http_service accessor" do
-    Koala.should respond_to(:http_service)
-    Koala.should respond_to(:http_service=)
+    expect(Koala).to respond_to(:http_service)
+    expect(Koala).to respond_to(:http_service=)
   end
 
   describe "constants" do
     it "has a version" do
-      Koala.const_defined?("VERSION").should be true
+      expect(Koala.const_defined?("VERSION")).to be true
     end
   end
 
@@ -23,21 +23,21 @@ describe Koala do
 
     it "invokes deprecated_interface if present" do
       mock_service = double("http service")
-      mock_service.should_receive(:deprecated_interface)
+      expect(mock_service).to receive(:deprecated_interface)
       Koala.http_service = mock_service
     end
 
     it "does not set the service if it's deprecated" do
       mock_service = double("http service")
-      mock_service.stub(:deprecated_interface)
+      allow(mock_service).to receive(:deprecated_interface)
       Koala.http_service = mock_service
-      Koala.http_service.should == @service
+      expect(Koala.http_service).to eq(@service)
     end
 
     it "sets the service if it's not deprecated" do
       mock_service = double("http service")
       Koala.http_service = mock_service
-      Koala.http_service.should == mock_service
+      expect(Koala.http_service).to eq(mock_service)
     end
   end
 
@@ -48,7 +48,7 @@ describe Koala do
       verb = "get"
       options = {:c => :d}
 
-      Koala.http_service.should_receive(:make_request).with(path, args, verb, options)
+      expect(Koala.http_service).to receive(:make_request).with(path, args, verb, options)
       Koala.make_request(path, args, verb, options)
     end
   end
@@ -77,7 +77,7 @@ describe Koala do
       Koala.configure do |config|
         config.graph_server = "some-new.graph_server.com"
       end
-      Koala.config.graph_server.should == "some-new.graph_server.com"
+      expect(Koala.config.graph_server).to eq("some-new.graph_server.com")
     end
   end
 

--- a/spec/cases/legacy_spec.rb
+++ b/spec/cases/legacy_spec.rb
@@ -5,27 +5,27 @@ describe "legacy APIs" do
 
   it "deprecates the REST API" do
     api = Koala::Facebook::API.new
-    api.stub(:api)
-    Koala::Utils.should_receive(:deprecate)
+    allow(api).to receive(:api)
+    expect(Koala::Utils).to receive(:deprecate)
     api.rest_call("stuff")
   end
 
   describe Koala::Facebook::GraphAPI do
     describe "class consolidation" do
       before :each do
-        Koala::Utils.stub(:deprecate) # avoid actual messages to stderr
+        allow(Koala::Utils).to receive(:deprecate) # avoid actual messages to stderr
       end
 
       it "still allows you to instantiate a GraphAndRestAPI object" do
-        api = Koala::Facebook::GraphAPI.new("token").should be_a(Koala::Facebook::GraphAPI)
+        api = expect(Koala::Facebook::GraphAPI.new("token")).to be_a(Koala::Facebook::GraphAPI)
       end
 
       it "ultimately creates an API object" do
-        api = Koala::Facebook::GraphAPI.new("token").should be_a(Koala::Facebook::API)
+        api = expect(Koala::Facebook::GraphAPI.new("token")).to be_a(Koala::Facebook::API)
       end
 
       it "fires a depreciation warning" do
-        Koala::Utils.should_receive(:deprecate)
+        expect(Koala::Utils).to receive(:deprecate)
         api = Koala::Facebook::GraphAPI.new("token")
       end
     end
@@ -34,19 +34,19 @@ describe "legacy APIs" do
   describe Koala::Facebook::RestAPI do
     describe "class consolidation" do
       before :each do
-        Koala::Utils.stub(:deprecate) # avoid actual messages to stderr
+        allow(Koala::Utils).to receive(:deprecate) # avoid actual messages to stderr
       end
 
       it "still allows you to instantiate a GraphAndRestAPI object" do
-        api = Koala::Facebook::RestAPI.new("token").should be_a(Koala::Facebook::RestAPI)
+        api = expect(Koala::Facebook::RestAPI.new("token")).to be_a(Koala::Facebook::RestAPI)
       end
 
       it "ultimately creates an API object" do
-        api = Koala::Facebook::RestAPI.new("token").should be_a(Koala::Facebook::API)
+        api = expect(Koala::Facebook::RestAPI.new("token")).to be_a(Koala::Facebook::API)
       end
 
       it "fires a depreciation warning" do
-        Koala::Utils.should_receive(:deprecate)
+        expect(Koala::Utils).to receive(:deprecate)
         api = Koala::Facebook::RestAPI.new("token")
       end
     end
@@ -55,19 +55,19 @@ describe "legacy APIs" do
   describe Koala::Facebook::GraphAndRestAPI do
     describe "class consolidation" do
       before :each do
-        Koala::Utils.stub(:deprecate) # avoid actual messages to stderr
+        allow(Koala::Utils).to receive(:deprecate) # avoid actual messages to stderr
       end
 
       it "still allows you to instantiate a GraphAndRestAPI object" do
-        api = Koala::Facebook::GraphAndRestAPI.new("token").should be_a(Koala::Facebook::GraphAndRestAPI)
+        api = expect(Koala::Facebook::GraphAndRestAPI.new("token")).to be_a(Koala::Facebook::GraphAndRestAPI)
       end
 
       it "ultimately creates an API object" do
-        api = Koala::Facebook::GraphAndRestAPI.new("token").should be_a(Koala::Facebook::API)
+        api = expect(Koala::Facebook::GraphAndRestAPI.new("token")).to be_a(Koala::Facebook::API)
       end
 
       it "fires a depreciation warning" do
-        Koala::Utils.should_receive(:deprecate)
+        expect(Koala::Utils).to receive(:deprecate)
         api = Koala::Facebook::GraphAndRestAPI.new("token")
       end
     end
@@ -76,40 +76,40 @@ describe "legacy APIs" do
   {:typhoeus => Koala::TyphoeusService, :net_http => Koala::NetHTTPService}.each_pair do |adapter, module_class|
     describe module_class.to_s do
       it "responds to deprecated_interface" do
-        module_class.should respond_to(:deprecated_interface)
+        expect(module_class).to respond_to(:deprecated_interface)
       end
 
       it "issues a deprecation warning" do
-        Koala::Utils.should_receive(:deprecate)
+        expect(Koala::Utils).to receive(:deprecate)
         module_class.deprecated_interface
       end
 
       it "sets the default adapter to #{adapter}" do
         module_class.deprecated_interface
-        Faraday.default_adapter.should == adapter
+        expect(Faraday.default_adapter).to eq(adapter)
       end
     end
   end
 
   describe "moved classes" do
     it "allows you to access Koala::HTTPService::MultipartRequest through the Koala module" do
-      Koala::MultipartRequest.should == Koala::HTTPService::MultipartRequest
+      expect(Koala::MultipartRequest).to eq(Koala::HTTPService::MultipartRequest)
     end
     
     it "allows you to access Koala::Response through the Koala module" do
-      Koala::Response.should == Koala::HTTPService::Response
+      expect(Koala::Response).to eq(Koala::HTTPService::Response)
     end
     
     it "allows you to access Koala::Response through the Koala module" do
-      Koala::UploadableIO.should == Koala::HTTPService::UploadableIO
+      expect(Koala::UploadableIO).to eq(Koala::HTTPService::UploadableIO)
     end
     
     it "allows you to access Koala::Facebook::GraphBatchAPI::BatchOperation through the Koala::Facebook module" do
-      Koala::Facebook::BatchOperation.should == Koala::Facebook::GraphBatchAPI::BatchOperation
+      expect(Koala::Facebook::BatchOperation).to eq(Koala::Facebook::GraphBatchAPI::BatchOperation)
     end 
     
     it "allows you to access Koala::Facebook::API::GraphCollection through the Koala::Facebook module" do
-      Koala::Facebook::GraphCollection.should == Koala::Facebook::API::GraphCollection
+      expect(Koala::Facebook::GraphCollection).to eq(Koala::Facebook::API::GraphCollection)
     end   
   end
 end

--- a/spec/cases/multipart_request_spec.rb
+++ b/spec/cases/multipart_request_spec.rb
@@ -2,44 +2,47 @@ require 'spec_helper'
 
 describe Koala::HTTPService::MultipartRequest do
   it "is a subclass of Faraday::Request::Multipart" do
-    Koala::HTTPService::MultipartRequest.superclass.should == Faraday::Request::Multipart
+    expect(Koala::HTTPService::MultipartRequest.superclass).to eq(Faraday::Request::Multipart)
   end
   
   it "defines mime_type as multipart/form-data" do
-    Koala::HTTPService::MultipartRequest.mime_type.should == 'multipart/form-data'
+    expect(Koala::HTTPService::MultipartRequest.mime_type).to eq('multipart/form-data')
   end
   
   describe "#process_request?" do
     before :each do
       @env = {}
+      @env.stub(:body) {
+        @env[:body]
+      }
       @multipart = Koala::HTTPService::MultipartRequest.new
-      @multipart.stub(:request_type).and_return("")
+      allow(@multipart).to receive(:request_type).and_return("")
     end
     
     # no way to test the call to super, unfortunately
     it "returns true if env[:body] is a hash with at least one hash in its values" do
       @env[:body] = {:a => {:c => 2}}
-      @multipart.process_request?(@env).should be true
+      expect(@multipart.process_request?(@env)).to be true
     end
 
     it "returns true if env[:body] is a hash with at least one array in its values" do
       @env[:body] = {:a => [:c, 2]}
-      @multipart.process_request?(@env).should be true
+      expect(@multipart.process_request?(@env)).to be true
     end
 
     it "returns true if env[:body] is a hash with mixed objects in its values" do
       @env[:body] = {:a => [:c, 2], :b => {:e => :f}}
-      @multipart.process_request?(@env).should be true
+      expect(@multipart.process_request?(@env)).to be true
     end
 
     it "returns false if env[:body] is a string" do
       @env[:body] = "my body"
-      @multipart.process_request?(@env).should be false
+      expect(@multipart.process_request?(@env)).to be false
     end
 
     it "returns false if env[:body] is a hash without an array or hash value" do
       @env[:body] = {:a => 3}
-      @multipart.process_request?(@env).should be false
+      expect(@multipart.process_request?(@env)).to be false
     end    
   end
   
@@ -52,14 +55,14 @@ describe Koala::HTTPService::MultipartRequest do
     
     it "is identical to the parent for requests without a prefix" do
       hash = {:a => 2, :c => "3"}
-      @multipart.process_params(hash, &@block).should == @parent.process_params(hash, &@block)
+      expect(@multipart.process_params(hash, &@block)).to eq(@parent.process_params(hash, &@block))
     end
     
     it "replaces encodes [ and ] if the request has a prefix" do
       hash = {:a => 2, :c => "3"}
       prefix = "foo"
       # process_params returns an array
-      @multipart.process_params(hash, prefix, &@block).join("&").should == @parent.process_params(hash, prefix, &@block).join("&").gsub(/\[/, "%5B").gsub(/\]/, "%5D")
+      expect(@multipart.process_params(hash, prefix, &@block).join("&")).to eq(@parent.process_params(hash, prefix, &@block).join("&").gsub(/\[/, "%5B").gsub(/\]/, "%5D"))
     end
   end
   

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -28,19 +28,19 @@ describe "Koala::Facebook::OAuth" do
 
   before :each do
     @time = Time.now
-    Time.stub(:now).and_return(@time)
-    @time.stub(:to_i).and_return(1273363199)
+    allow(Time).to receive(:now).and_return(@time)
+    allow(@time).to receive(:to_i).and_return(1273363199)
   end
 
   describe ".new" do
     it "properly initializes" do
-      @oauth.should
+      expect(@oauth).to be_truthy
     end
 
     it "properly sets attributes" do
-      (@oauth.app_id == @app_id &&
+      expect(@oauth.app_id == @app_id &&
         @oauth.app_secret == @secret &&
-        @oauth.oauth_callback_url == @callback_url).should be true
+        @oauth.oauth_callback_url == @callback_url).to be true
     end
 
     it "properly initializes without a callback_url" do
@@ -49,9 +49,9 @@ describe "Koala::Facebook::OAuth" do
 
     it "properly sets attributes without a callback URL" do
       @oauth = Koala::Facebook::OAuth.new(@app_id, @secret)
-      (@oauth.app_id == @app_id &&
+      expect(@oauth.app_id == @app_id &&
         @oauth.app_secret == @secret &&
-        @oauth.oauth_callback_url == nil).should be true
+        @oauth.oauth_callback_url == nil).to be true
     end
   end
 
@@ -62,71 +62,71 @@ describe "Koala::Facebook::OAuth" do
           # we don't actually want to make requests to Facebook to redeem the code
           @cookie = KoalaTest.oauth_test_data["valid_signed_cookies"]
           @token = "my token"
-          @oauth.stub(:get_access_token_info).and_return("access_token" => @token)
+          allow(@oauth).to receive(:get_access_token_info).and_return("access_token" => @token)
         end
 
         it "parses valid cookies" do
           result = @oauth.get_user_info_from_cookies(@cookie)
-          result.should be_a(Hash)
+          expect(result).to be_a(Hash)
         end
 
         it "returns all the components in the signed request" do
           result = @oauth.get_user_info_from_cookies(@cookie)
           @oauth.parse_signed_request(@cookie.values.first).each_pair do |k, v|
-            result[k].should == v
+            expect(result[k]).to eq(v)
           end
         end
 
         it "makes a request to Facebook to redeem the code if present" do
           code = "foo"
-          @oauth.stub(:parse_signed_request).and_return({"code" => code})
-          @oauth.should_receive(:get_access_token_info).with(code, anything)
+          allow(@oauth).to receive(:parse_signed_request).and_return({"code" => code})
+          expect(@oauth).to receive(:get_access_token_info).with(code, anything)
           @oauth.get_user_info_from_cookies(@cookie)
         end
 
         it "sets the code redemption redirect_uri to ''" do
-          @oauth.should_receive(:get_access_token_info).with(anything, :redirect_uri => '')
+          expect(@oauth).to receive(:get_access_token_info).with(anything, :redirect_uri => '')
           @oauth.get_user_info_from_cookies(@cookie)
         end
 
         context "if the code is missing" do
           it "doesn't make a request to Facebook" do
-            @oauth.stub(:parse_signed_request).and_return({})
-            @oauth.should_receive(:get_access_token_info).never
+            allow(@oauth).to receive(:parse_signed_request).and_return({})
+            expect(@oauth).to receive(:get_access_token_info).never
             @oauth.get_user_info_from_cookies(@cookie)
           end
 
           it "returns nil" do
-            @oauth.stub(:parse_signed_request).and_return({})
-            @oauth.get_user_info_from_cookies(@cookie).should be_nil
+            allow(@oauth).to receive(:parse_signed_request).and_return({})
+            expect(@oauth.get_user_info_from_cookies(@cookie)).to be_nil
           end
 
           it "logs a warning" do
-            @oauth.stub(:parse_signed_request).and_return({})
-            Koala::Utils.logger.should_receive(:warn)
+            allow(@oauth).to receive(:parse_signed_request).and_return({})
+            expect(Koala::Utils.logger).to receive(:warn)
             @oauth.get_user_info_from_cookies(@cookie)
           end
         end
 
         context "if the code is present" do
           it "adds the access_token into the hash" do
-            @oauth.get_user_info_from_cookies(@cookie)["access_token"].should == @token
+            expect(@oauth.get_user_info_from_cookies(@cookie)["access_token"]).to eq(@token)
           end
 
           it "returns nil if the call to FB returns no data" do
-            @oauth.stub(:get_access_token_info).and_return(nil)
-            @oauth.get_user_info_from_cookies(@cookie).should be_nil
+            allow(@oauth).to receive(:get_access_token_info).and_return(nil)
+            expect(@oauth.get_user_info_from_cookies(@cookie)).to be_nil
           end
 
           it "returns nil if the call to FB returns an expired code error" do
-            @oauth.stub(:get_access_token_info).and_raise(Koala::Facebook::OAuthTokenRequestError.new(400,
+            allow(@oauth).to receive(:get_access_token_info).and_raise(Koala::Facebook::OAuthTokenRequestError.new(400,
               '{ "error": { "type": "OAuthException", "message": "Code was invalid or expired. Session has expired at unix time 1324044000. The current unix time is 1324300957." } }'
             ))
-            @oauth.get_user_info_from_cookies(@cookie).should be_nil
+            expect(@oauth.get_user_info_from_cookies(@cookie)).to be_nil
           end
 
           it "raises the error if the call to FB returns a different error" do
-            @oauth.stub(:get_access_token_info).and_raise(Koala::Facebook::OAuthTokenRequestError.new(400,
+            allow(@oauth).to receive(:get_access_token_info).and_raise(Koala::Facebook::OAuthTokenRequestError.new(400,
               '{ "error": { "type": "OtherError", "message": "A Facebook Error" } }'))
             expect { @oauth.get_user_info_from_cookies(@cookie) }.to raise_exception(Koala::Facebook::OAuthTokenRequestError)
           end
@@ -136,46 +136,46 @@ describe "Koala::Facebook::OAuth" do
           # make an invalid string by replacing some values
           bad_cookie_hash = @cookie.inject({}) { |hash, value| hash[value[0]] = value[1].gsub(/[0-9]/, "3") }
           result = @oauth.get_user_info_from_cookies(bad_cookie_hash)
-          result.should be_nil
+          expect(result).to be_nil
         end
       end
 
       context "for unsigned cookies" do
         it "properly parses valid cookies" do
           result = @oauth.get_user_info_from_cookies(KoalaTest.oauth_test_data["valid_cookies"])
-          result.should be_a(Hash)
+          expect(result).to be_a(Hash)
         end
 
         it "returns all the cookie components from valid cookie string" do
           cookie_data = KoalaTest.oauth_test_data["valid_cookies"]
           parsing_results = @oauth.get_user_info_from_cookies(cookie_data)
           number_of_components = cookie_data["fbs_#{@app_id.to_s}"].scan(/\=/).length
-          parsing_results.length.should == number_of_components
+          expect(parsing_results.length).to eq(number_of_components)
         end
 
         it "properly parses valid offline access cookies (e.g. no expiration)" do
           result = @oauth.get_user_info_from_cookies(KoalaTest.oauth_test_data["offline_access_cookies"])
-          result["uid"].should
+          expect(result["uid"]).to be_truthy
         end
 
         it "returns all the cookie components from offline access cookies" do
           cookie_data = KoalaTest.oauth_test_data["offline_access_cookies"]
           parsing_results = @oauth.get_user_info_from_cookies(cookie_data)
           number_of_components = cookie_data["fbs_#{@app_id.to_s}"].scan(/\=/).length
-          parsing_results.length.should == number_of_components
+          expect(parsing_results.length).to eq(number_of_components)
         end
 
         it "doesn't parse expired cookies" do
           new_time = @time.to_i * 2
-          @time.stub(:to_i).and_return(new_time)
-          @oauth.get_user_info_from_cookies(KoalaTest.oauth_test_data["valid_cookies"]).should be_nil
+          allow(@time).to receive(:to_i).and_return(new_time)
+          expect(@oauth.get_user_info_from_cookies(KoalaTest.oauth_test_data["valid_cookies"])).to be_nil
         end
 
         it "doesn't parse invalid cookies" do
           # make an invalid string by replacing some values
           bad_cookie_hash = KoalaTest.oauth_test_data["valid_cookies"].inject({}) { |hash, value| hash[value[0]] = value[1].gsub(/[0-9]/, "3") }
           result = @oauth.get_user_info_from_cookies(bad_cookie_hash)
-          result.should be_nil
+          expect(result).to be_nil
         end
       end
     end
@@ -185,28 +185,28 @@ describe "Koala::Facebook::OAuth" do
         before :each do
           # we don't actually want to make requests to Facebook to redeem the code
           @cookie = KoalaTest.oauth_test_data["valid_signed_cookies"]
-          @oauth.stub(:get_access_token_info).and_return("access_token" => "my token")
+          allow(@oauth).to receive(:get_access_token_info).and_return("access_token" => "my token")
         end
 
         it "does not uses get_user_info_from_cookies to parse the cookies" do
-          @oauth.should_not_receive(:get_user_info_from_cookies).with(@cookie)
+          expect(@oauth).not_to receive(:get_user_info_from_cookies).with(@cookie)
           @oauth.get_user_from_cookies(@cookie)
         end
 
         it "uses return the facebook user id string if the cookies are valid" do
           result = @oauth.get_user_from_cookies(@cookie)
-          result.should == "2905623" # the user who generated the original test cookie
+          expect(result).to eq("2905623") # the user who generated the original test cookie
         end
 
         it "returns nil if the cookies are invalid" do
           # make an invalid string by replacing some values
           bad_cookie_hash = @cookie.inject({}) { |hash, value| hash[value[0]] = value[1].gsub(/[0-9]/, "3") }
           result = @oauth.get_user_from_cookies(bad_cookie_hash)
-          result.should be_nil
+          expect(result).to be_nil
         end
 
         it "is deprecated" do
-          Koala::Utils.should_receive(:deprecate)
+          expect(Koala::Utils).to receive(:deprecate)
           @oauth.get_user_from_cookies({})
         end
       end
@@ -218,20 +218,20 @@ describe "Koala::Facebook::OAuth" do
         end
 
         it "uses get_user_info_from_cookies to parse the cookies" do
-          @oauth.should_receive(:get_user_info_from_cookies).with(@cookie).and_return({})
+          expect(@oauth).to receive(:get_user_info_from_cookies).with(@cookie).and_return({})
           @oauth.get_user_from_cookies(@cookie)
         end
 
         it "uses return a string if the cookies are valid" do
           result = @oauth.get_user_from_cookies(@cookie)
-          result.should == "2905623" # the user who generated the original test cookie
+          expect(result).to eq("2905623") # the user who generated the original test cookie
         end
 
         it "returns nil if the cookies are invalid" do
           # make an invalid string by replacing some values
           bad_cookie_hash = @cookie.inject({}) { |hash, value| hash[value[0]] = value[1].gsub(/[0-9]/, "3") }
           result = @oauth.get_user_from_cookies(bad_cookie_hash)
-          result.should be_nil
+          expect(result).to be_nil
         end
       end
     end
@@ -241,42 +241,42 @@ describe "Koala::Facebook::OAuth" do
     describe "#url_for_oauth_code" do
       it "generates a properly formatted OAuth code URL with the default values" do
         url = @oauth.url_for_oauth_code
-        url.should match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&redirect_uri=#{CGI.escape @callback_url}")
+        expect(url).to match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&redirect_uri=#{CGI.escape @callback_url}")
       end
 
       it "generates a properly formatted OAuth code URL when a callback is given" do
         callback = "foo.com"
         url = @oauth.url_for_oauth_code(:callback => callback)
-        url.should match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&redirect_uri=#{callback}")
+        expect(url).to match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&redirect_uri=#{callback}")
       end
 
       it "generates a properly formatted OAuth code URL when permissions are requested as a string" do
         permissions = "publish_stream,read_stream"
         url = @oauth.url_for_oauth_code(:permissions => permissions)
-        url.should match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&scope=#{CGI.escape permissions}&redirect_uri=#{CGI.escape @callback_url}")
+        expect(url).to match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&scope=#{CGI.escape permissions}&redirect_uri=#{CGI.escape @callback_url}")
       end
 
       it "generates a properly formatted OAuth code URL when permissions are requested as a string" do
         permissions = ["publish_stream", "read_stream"]
         url = @oauth.url_for_oauth_code(:permissions => permissions)
-        url.should match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&scope=#{CGI.escape permissions.join(",")}&redirect_uri=#{CGI.escape @callback_url}")
+        expect(url).to match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&scope=#{CGI.escape permissions.join(",")}&redirect_uri=#{CGI.escape @callback_url}")
       end
 
       it "generates a properly formatted OAuth code URL when both permissions and callback are provided" do
         permissions = "publish_stream,read_stream"
         callback = "foo.com"
         url = @oauth.url_for_oauth_code(:callback => callback, :permissions => permissions)
-        url.should match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&scope=#{CGI.escape permissions}&redirect_uri=#{CGI.escape callback}")
+        expect(url).to match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&scope=#{CGI.escape permissions}&redirect_uri=#{CGI.escape callback}")
       end
 
       it "generates a properly formatted OAuth code URL when a display is given as a string" do
         url = @oauth.url_for_oauth_code(:display => "page")
-        url.should match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&display=page&redirect_uri=#{CGI.escape @callback_url}")
+        expect(url).to match_url("https://#{Koala.config.dialog_host}/dialog/oauth?client_id=#{@app_id}&display=page&redirect_uri=#{CGI.escape @callback_url}")
       end
 
       it "raises an exception if no callback is given in initialization or the call" do
         oauth2 = Koala::Facebook::OAuth.new(@app_id, @secret)
-        lambda { oauth2.url_for_oauth_code }.should raise_error(ArgumentError)
+        expect { oauth2.url_for_oauth_code }.to raise_error(ArgumentError)
       end
 
       it "includes any additional options as URL parameters, appropriately escaped" do
@@ -286,7 +286,7 @@ describe "Koala::Facebook::OAuth" do
         }
         url = @oauth.url_for_oauth_code(params)
         params.each_pair do |key, value|
-          url.should =~ /[\&\?]#{key}=#{CGI.escape value}/
+          expect(url).to match(/[\&\?]#{key}=#{CGI.escape value}/)
         end
       end
     end
@@ -299,13 +299,13 @@ describe "Koala::Facebook::OAuth" do
 
       it "generates a properly formatted OAuth token URL when provided a code" do
         url = @oauth.url_for_access_token(@code)
-        url.should match_url("https://#{Koala.config.graph_server}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape @callback_url}")
+        expect(url).to match_url("https://#{Koala.config.graph_server}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape @callback_url}")
       end
 
       it "generates a properly formatted OAuth token URL when provided a callback" do
         callback = "foo.com"
         url = @oauth.url_for_access_token(@code, :callback => callback)
-        url.should match_url("https://#{Koala.config.graph_server}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape callback}")
+        expect(url).to match_url("https://#{Koala.config.graph_server}/oauth/access_token?client_id=#{@app_id}&code=#{@code}&client_secret=#{@secret}&redirect_uri=#{CGI.escape callback}")
       end
 
       it "includes any additional options as URL parameters, appropriately escaped" do
@@ -315,7 +315,7 @@ describe "Koala::Facebook::OAuth" do
         }
         url = @oauth.url_for_access_token(@code, params)
         params.each_pair do |key, value|
-          url.should =~ /[\&\?]#{key}=#{CGI.escape value}/
+          expect(url).to match(/[\&\?]#{key}=#{CGI.escape value}/)
         end
       end
     end
@@ -323,7 +323,7 @@ describe "Koala::Facebook::OAuth" do
     describe "#url_for_dialog" do
       it "builds the base properly" do
         dialog_type = "my_dialog_type"
-        @oauth.url_for_dialog(dialog_type).should =~ /^http:\/\/#{Koala.config.dialog_host}\/dialog\/#{dialog_type}/
+        expect(@oauth.url_for_dialog(dialog_type)).to match(/^http:\/\/#{Koala.config.dialog_host}\/dialog\/#{dialog_type}/)
       end
 
       it "adds the app_id/client_id to the url" do
@@ -331,7 +331,7 @@ describe "Koala::Facebook::OAuth" do
         url = @oauth.url_for_dialog("foo", automatic_params)
         automatic_params.each_pair do |key, value|
           # we're slightly simplifying how encode_params works, but for strings/ints, it's okay
-          url.should =~ /[\&\?]#{key}=#{CGI.escape value.to_s}/
+          expect(url).to match(/[\&\?]#{key}=#{CGI.escape value.to_s}/)
         end
       end
 
@@ -343,7 +343,7 @@ describe "Koala::Facebook::OAuth" do
         url = @oauth.url_for_dialog("friends", params)
         params.each_pair do |key, value|
           # we're slightly simplifying how encode_params works, but strings/ints, it's okay
-          url.should =~ /[\&\?]#{key}=#{CGI.escape value.to_s}/
+          expect(url).to match(/[\&\?]#{key}=#{CGI.escape value.to_s}/)
         end
       end
 
@@ -352,22 +352,22 @@ describe "Koala::Facebook::OAuth" do
         # slightly brittle (e.g. if parameter order changes), but still useful
         it "can generate a send dialog" do
           url = @oauth.url_for_dialog("send", :name => "People Argue Just to Win", :link => "http://www.nytimes.com/2011/06/15/arts/people-argue-just-to-win-scholars-assert.html")
-          url.should match_url("http://www.facebook.com/dialog/send?app_id=#{@app_id}&client_id=#{@app_id}&link=http%3A%2F%2Fwww.nytimes.com%2F2011%2F06%2F15%2Farts%2Fpeople-argue-just-to-win-scholars-assert.html&name=People+Argue+Just+to+Win&redirect_uri=#{CGI.escape @callback_url}")
+          expect(url).to match_url("http://www.facebook.com/dialog/send?app_id=#{@app_id}&client_id=#{@app_id}&link=http%3A%2F%2Fwww.nytimes.com%2F2011%2F06%2F15%2Farts%2Fpeople-argue-just-to-win-scholars-assert.html&name=People+Argue+Just+to+Win&redirect_uri=#{CGI.escape @callback_url}")
         end
 
         it "can generate a feed dialog" do
           url = @oauth.url_for_dialog("feed", :name => "People Argue Just to Win", :link => "http://www.nytimes.com/2011/06/15/arts/people-argue-just-to-win-scholars-assert.html")
-          url.should match_url("http://www.facebook.com/dialog/feed?app_id=#{@app_id}&client_id=#{@app_id}&link=http%3A%2F%2Fwww.nytimes.com%2F2011%2F06%2F15%2Farts%2Fpeople-argue-just-to-win-scholars-assert.html&name=People+Argue+Just+to+Win&redirect_uri=#{CGI.escape @callback_url}")
+          expect(url).to match_url("http://www.facebook.com/dialog/feed?app_id=#{@app_id}&client_id=#{@app_id}&link=http%3A%2F%2Fwww.nytimes.com%2F2011%2F06%2F15%2Farts%2Fpeople-argue-just-to-win-scholars-assert.html&name=People+Argue+Just+to+Win&redirect_uri=#{CGI.escape @callback_url}")
         end
 
         it "can generate a oauth dialog" do
           url = @oauth.url_for_dialog("oauth", :scope => "email", :response_type => "token")
-          url.should match_url("http://www.facebook.com/dialog/oauth?app_id=#{@app_id}&client_id=#{@app_id}&redirect_uri=#{CGI.escape @callback_url}&response_type=token&scope=email")
+          expect(url).to match_url("http://www.facebook.com/dialog/oauth?app_id=#{@app_id}&client_id=#{@app_id}&redirect_uri=#{CGI.escape @callback_url}&response_type=token&scope=email")
         end
 
         it "can generate a pay dialog" do
           url = @oauth.url_for_dialog("pay", :order_id => "foo", :credits_purchase => false)
-          url.should match_url("http://www.facebook.com/dialog/pay?app_id=#{@app_id}&client_id=#{@app_id}&order_id=foo&credits_purchase=false&redirect_uri=#{CGI.escape @callback_url}")
+          expect(url).to match_url("http://www.facebook.com/dialog/pay?app_id=#{@app_id}&client_id=#{@app_id}&order_id=foo&credits_purchase=false&redirect_uri=#{CGI.escape @callback_url}")
         end
       end
     end
@@ -377,35 +377,35 @@ describe "Koala::Facebook::OAuth" do
     describe '#generate_client_code' do
       if KoalaTest.mock_interface? || KoalaTest.oauth_token
         it 'makes a request using the correct endpoint' do
-          Koala.should_receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '{"code": "fake_client_code"}', {}))
+          expect(Koala).to receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '{"code": "fake_client_code"}', {}))
           @oauth.generate_client_code(KoalaTest.oauth_token)
         end
 
         it 'gets a valid client code returned' do
-          Koala.should_receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '{"code": "fake_client_code"}', {}))
+          expect(Koala).to receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '{"code": "fake_client_code"}', {}))
           result = @oauth.generate_client_code(KoalaTest.oauth_token)
-          result.should be_a(String)
-          result.should eq('fake_client_code')
+          expect(result).to be_a(String)
+          expect(result).to eq('fake_client_code')
         end
 
         it 'raises a BadFacebookResponse error when empty response body is returned' do
-          Koala.should_receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '', {}))
-          lambda { @oauth.generate_client_code(KoalaTest.oauth_token) }.should raise_error(Koala::Facebook::BadFacebookResponse)
+          expect(Koala).to receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '', {}))
+          expect { @oauth.generate_client_code(KoalaTest.oauth_token) }.to raise_error(Koala::Facebook::BadFacebookResponse)
         end
 
         it 'raises an OAuthTokenRequestError when empty response body is returned' do
-          Koala.should_receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(400, '', {}))
-          lambda { @oauth.generate_client_code(KoalaTest.oauth_token) }.should raise_error(Koala::Facebook::OAuthTokenRequestError)
+          expect(Koala).to receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(400, '', {}))
+          expect { @oauth.generate_client_code(KoalaTest.oauth_token) }.to raise_error(Koala::Facebook::OAuthTokenRequestError)
         end
 
         it 'raises a ServerError when empty response body is returned' do
-          Koala.should_receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(500, '', {}))
-          lambda { @oauth.generate_client_code(KoalaTest.oauth_token) }.should raise_error(Koala::Facebook::ServerError)
+          expect(Koala).to receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(500, '', {}))
+          expect { @oauth.generate_client_code(KoalaTest.oauth_token) }.to raise_error(Koala::Facebook::ServerError)
         end
 
         it 'raises a KoalaError when empty response body is returned' do
-          Koala.should_receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '{"client_code":"should_not_be_returned"}', {}))
-          lambda { @oauth.generate_client_code(KoalaTest.oauth_token) }.should raise_error(Koala::KoalaError)
+          expect(Koala).to receive(:make_request).with('/oauth/client_code', anything, 'get', anything).and_return(Koala::HTTPService::Response.new(200, '{"client_code":"should_not_be_returned"}', {}))
+          expect { @oauth.generate_client_code(KoalaTest.oauth_token) }.to raise_error(Koala::KoalaError)
         end
       else
         pending "Some OAuth token exchange tests will not be run since the access token field in facebook_data.yml is blank."
@@ -417,33 +417,33 @@ describe "Koala::Facebook::OAuth" do
     describe "#get_access_token_info" do
       it "uses options[:redirect_uri] if provided" do
         uri = "foo"
-        Koala.should_receive(:make_request).with(anything, hash_including(:redirect_uri => uri), anything, anything).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, hash_including(:redirect_uri => uri), anything, anything).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.get_access_token_info(@code, :redirect_uri => uri)
       end
 
       it "uses the redirect_uri used to create the @oauth if no :redirect_uri option is provided" do
-        Koala.should_receive(:make_request).with(anything, hash_including(:redirect_uri => @callback_url), anything, anything).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, hash_including(:redirect_uri => @callback_url), anything, anything).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.get_access_token_info(@code)
       end
 
       it "makes a GET request" do
-        Koala.should_receive(:make_request).with(anything, anything, "get", anything).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, anything, "get", anything).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.get_access_token_info(@code)
       end
 
       if KoalaTest.code
         it "properly gets and parses an access token token results into a hash" do
           result = @oauth.get_access_token_info(@code)
-          result.should be_a(Hash)
+          expect(result).to be_a(Hash)
         end
 
         it "properly includes the access token results" do
           result = @oauth.get_access_token_info(@code)
-          result["access_token"].should
+          expect(result["access_token"]).to be_truthy
         end
 
         it "raises an error when get_access_token is called with a bad code" do
-          lambda { @oauth.get_access_token_info("foo") }.should raise_error(Koala::Facebook::OAuthTokenRequestError)
+          expect { @oauth.get_access_token_info("foo") }.to raise_error(Koala::Facebook::OAuthTokenRequestError)
         end
       end
     end
@@ -452,24 +452,24 @@ describe "Koala::Facebook::OAuth" do
       # TODO refactor these to be proper tests with stubs and tests against real data
       it "passes on any options provided to make_request" do
         options = {:a => 2}
-        Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.get_access_token(@code, options)
       end
 
       if KoalaTest.code
         it "uses get_access_token_info to get and parse an access token token results" do
           result = @oauth.get_access_token(@code)
-          result.should be_a(String)
+          expect(result).to be_a(String)
         end
 
         it "returns the access token as a string" do
           result = @oauth.get_access_token(@code)
           original = @oauth.get_access_token_info(@code)
-          result.should == original["access_token"]
+          expect(result).to eq(original["access_token"])
         end
 
         it "raises an error when get_access_token is called with a bad code" do
-          lambda { @oauth.get_access_token("foo") }.should raise_error(Koala::Facebook::OAuthTokenRequestError)
+          expect { @oauth.get_access_token("foo") }.to raise_error(Koala::Facebook::OAuthTokenRequestError)
         end
       end
     end
@@ -481,17 +481,17 @@ describe "Koala::Facebook::OAuth" do
     describe "get_app_access_token_info" do
       it "properly gets and parses an app's access token as a hash" do
         result = @oauth.get_app_access_token_info
-        result.should be_a(Hash)
+        expect(result).to be_a(Hash)
       end
 
       it "includes the access token" do
         result = @oauth.get_app_access_token_info
-        result["access_token"].should
+        expect(result["access_token"]).to be_truthy
       end
 
       it "passes on any options provided to make_request" do
         options = {:a => 2}
-        Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.get_app_access_token_info(options)
       end
     end
@@ -499,18 +499,18 @@ describe "Koala::Facebook::OAuth" do
     describe "get_app_access_token" do
       it "uses get_access_token_info to get and parse an access token token results" do
         result = @oauth.get_app_access_token
-        result.should be_a(String)
+        expect(result).to be_a(String)
       end
 
       it "returns the access token as a string" do
         result = @oauth.get_app_access_token
         original = @oauth.get_app_access_token_info
-        result.should == original["access_token"]
+        expect(result).to eq(original["access_token"])
       end
 
       it "passes on any options provided to make_request" do
         options = {:a => 2}
-        Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.get_app_access_token(options)
       end
     end
@@ -519,12 +519,12 @@ describe "Koala::Facebook::OAuth" do
       if KoalaTest.mock_interface? || KoalaTest.oauth_token
         it "properly gets and parses an app's access token as a hash" do
           result = @oauth.exchange_access_token_info(KoalaTest.oauth_token)
-          result.should be_a(Hash)
+          expect(result).to be_a(Hash)
         end
 
         it "includes the access token" do
           result = @oauth.exchange_access_token_info(KoalaTest.oauth_token)
-          result["access_token"].should
+          expect(result["access_token"]).not_to be_nil
         end
       else
         pending "Some OAuth token exchange tests will not be run since the access token field in facebook_data.yml is blank."
@@ -532,25 +532,25 @@ describe "Koala::Facebook::OAuth" do
 
       it "passes on any options provided to make_request" do
         options = {:a => 2}
-        Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.exchange_access_token_info(KoalaTest.oauth_token, options)
       end
 
       it "raises an error when exchange_access_token_info is called with a bad code" do
-        lambda { @oauth.exchange_access_token_info("foo") }.should raise_error(Koala::Facebook::OAuthTokenRequestError)
+        expect { @oauth.exchange_access_token_info("foo") }.to raise_error(Koala::Facebook::OAuthTokenRequestError)
       end
     end
 
     describe "exchange_access_token" do
       it "uses get_access_token_info to get and parse an access token token results" do
         hash = {"access_token" => Time.now.to_i * rand}
-        @oauth.stub(:exchange_access_token_info).and_return(hash)
-        @oauth.exchange_access_token(KoalaTest.oauth_token).should == hash["access_token"]
+        allow(@oauth).to receive(:exchange_access_token_info).and_return(hash)
+        expect(@oauth.exchange_access_token(KoalaTest.oauth_token)).to eq(hash["access_token"])
       end
 
       it "passes on any options provided to make_request" do
         options = {:a => 2}
-        Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
+        expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
         @oauth.exchange_access_token(KoalaTest.oauth_token, options)
       end
     end
@@ -563,13 +563,13 @@ describe "Koala::Facebook::OAuth" do
       it "properly parses access token results" do
         result = @oauth.send(:parse_access_token, @raw_token_string)
         has_both_parts = result["access_token"] && result["expires"]
-        has_both_parts.should
+        expect(has_both_parts).to be_truthy
       end
 
       it "properly parses offline access token results" do
         result = @oauth.send(:parse_access_token, @raw_offline_access_token_string)
         has_both_parts = result["access_token"] && !result["expires"]
-        has_both_parts.should
+        expect(has_both_parts).to be true
       end
 
       # fetch_token_string
@@ -578,7 +578,7 @@ describe "Koala::Facebook::OAuth" do
       if KoalaTest.code
         it "fetches a proper token string from Facebook when given a code" do
           result = @oauth.send(:fetch_token_string, :code => @code, :redirect_uri => @callback_url)
-          result.should =~ /^access_token/
+          expect(result).to match(/^access_token/)
         end
       else
         it "fetch_token_string code test will not be run since the code field in facebook_data.yml is blank."
@@ -586,7 +586,7 @@ describe "Koala::Facebook::OAuth" do
 
       it "fetches a proper token string from Facebook when asked for the app token" do
         result = @oauth.send(:fetch_token_string, {:grant_type => 'client_credentials'}, true)
-        result.should =~ /^access_token/
+        expect(result).to match(/^access_token/)
       end
     end
   end
@@ -596,41 +596,41 @@ describe "Koala::Facebook::OAuth" do
       describe "with get_token_info_from_session_keys" do
         it "gets an array of session keys from Facebook when passed a single key" do
           result = @oauth.get_tokens_from_session_keys([KoalaTest.session_key])
-          result.should be_an(Array)
-          result.length.should == 1
+          expect(result).to be_an(Array)
+          expect(result.length).to eq(1)
         end
 
         it "gets an array of session keys from Facebook when passed multiple keys" do
           result = @oauth.get_tokens_from_session_keys(@multiple_session_keys)
-          result.should be_an(Array)
-          result.length.should == 2
+          expect(result).to be_an(Array)
+          expect(result.length).to eq(2)
         end
 
         it "returns the original hashes" do
           result = @oauth.get_token_info_from_session_keys(@multiple_session_keys)
-          result[0].should be_a(Hash)
+          expect(result[0]).to be_a(Hash)
         end
 
         it "properly handles invalid session keys" do
           result = @oauth.get_token_info_from_session_keys(["foo", "bar"])
           #it should return nil for each of the invalid ones
-          result.each {|r| r.should be_nil}
+          result.each {|r| expect(r).to be_nil}
         end
 
         it "properly handles a mix of valid and invalid session keys" do
           result = @oauth.get_token_info_from_session_keys(["foo"].concat(@multiple_session_keys))
           # it should return nil for each of the invalid ones
-          result.each_with_index {|r, index| index > 0 ? r.should(be_a(Hash)) : r.should(be_nil)}
+          result.each_with_index {|r, index| index > 0 ? expect(r).to(be_a(Hash)) : expect(r).to(be_nil)}
         end
 
         it "throws a BadFacebookResponse if Facebook returns an empty body (as happens for instance when the API breaks)" do
-          @oauth.should_receive(:fetch_token_string).and_return("")
-          lambda { @oauth.get_token_info_from_session_keys(@multiple_session_keys) }.should raise_error(Koala::Facebook::BadFacebookResponse)
+          expect(@oauth).to receive(:fetch_token_string).and_return("")
+          expect { @oauth.get_token_info_from_session_keys(@multiple_session_keys) }.to raise_error(Koala::Facebook::BadFacebookResponse)
         end
 
         it "passes on any options provided to make_request" do
           options = {:a => 2}
-          Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "[{}]", {}))
+          expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "[{}]", {}))
           @oauth.get_token_info_from_session_keys([], options)
         end
       end
@@ -638,31 +638,31 @@ describe "Koala::Facebook::OAuth" do
       describe "with get_tokens_from_session_keys" do
         it "calls get_token_info_from_session_keys" do
           args = @multiple_session_keys
-          @oauth.should_receive(:get_token_info_from_session_keys).with(args, anything).and_return([])
+          expect(@oauth).to receive(:get_token_info_from_session_keys).with(args, anything).and_return([])
           @oauth.get_tokens_from_session_keys(args)
         end
 
         it "returns an array of strings" do
           args = @multiple_session_keys
           result = @oauth.get_tokens_from_session_keys(args)
-          result.each {|r| r.should be_a(String) }
+          result.each {|r| expect(r).to be_a(String) }
         end
 
         it "properly handles invalid session keys" do
           result = @oauth.get_tokens_from_session_keys(["foo", "bar"])
           # it should return nil for each of the invalid ones
-          result.each {|r| r.should be_nil}
+          result.each {|r| expect(r).to be_nil}
         end
 
         it "properly handles a mix of valid and invalid session keys" do
           result = @oauth.get_tokens_from_session_keys(["foo"].concat(@multiple_session_keys))
           # it should return nil for each of the invalid ones
-          result.each_with_index {|r, index| index > 0 ? r.should(be_a(String)) : r.should(be_nil)}
+          result.each_with_index {|r, index| index > 0 ? expect(r).to(be_a(String)) : expect(r).to(be_nil)}
         end
 
         it "passes on any options provided to make_request" do
           options = {:a => 2}
-          Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "[{}]", {}))
+          expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "[{}]", {}))
           @oauth.get_tokens_from_session_keys([], options)
         end
       end
@@ -670,29 +670,29 @@ describe "Koala::Facebook::OAuth" do
       describe "get_token_from_session_key" do
         it "calls get_tokens_from_session_keys when the get_token_from_session_key is called" do
           key = KoalaTest.session_key
-          @oauth.should_receive(:get_tokens_from_session_keys).with([key], anything).and_return([])
+          expect(@oauth).to receive(:get_tokens_from_session_keys).with([key], anything).and_return([])
           @oauth.get_token_from_session_key(key)
         end
 
         it "gets back the access token string from get_token_from_session_key" do
           result = @oauth.get_token_from_session_key(KoalaTest.session_key)
-          result.should be_a(String)
+          expect(result).to be_a(String)
         end
 
         it "returns the first value in the array" do
           result = @oauth.get_token_from_session_key(KoalaTest.session_key)
           array = @oauth.get_tokens_from_session_keys([KoalaTest.session_key])
-          result.should == array[0]
+          expect(result).to eq(array[0])
         end
 
         it "properly handles an invalid session key" do
           result = @oauth.get_token_from_session_key("foo")
-          result.should be_nil
+          expect(result).to be_nil
         end
 
         it "passes on any options provided to make_request" do
           options = {:a => 2}
-          Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "[{}]", {}))
+          expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "[{}]", {}))
           @oauth.get_token_from_session_key("", options)
         end
       end
@@ -705,24 +705,24 @@ describe "Koala::Facebook::OAuth" do
     # the signed request code is ported directly from Facebook
     # so we only need to test at a high level that it works
     it "throws an error if the algorithm is unsupported" do
-      MultiJson.stub(:load).and_return("algorithm" => "my fun algorithm")
-      lambda { @oauth.parse_signed_request(@signed_request) }.should raise_error
+      allow(MultiJson).to receive(:load).and_return("algorithm" => "my fun algorithm")
+      expect { @oauth.parse_signed_request(@signed_request) }.to raise_error
     end
 
     it "throws an error if the signature is invalid" do
-      OpenSSL::HMAC.stub(:hexdigest).and_return("i'm an invalid signature")
-      lambda { @oauth.parse_signed_request(@signed_request) }.should raise_error
+      allow(OpenSSL::HMAC).to receive(:hexdigest).and_return("i'm an invalid signature")
+      expect { @oauth.parse_signed_request(@signed_request) }.to raise_error
     end
 
     it "throws an error if the signature string is empty" do
       # this occasionally happens due to Facebook error
-      lambda { @oauth.parse_signed_request("") }.should raise_error
-      lambda { @oauth.parse_signed_request("abc-def") }.should raise_error
+      expect { @oauth.parse_signed_request("") }.to raise_error
+      expect { @oauth.parse_signed_request("abc-def") }.to raise_error
     end
 
     it "properly parses requests" do
       @oauth = Koala::Facebook::OAuth.new(@app_id, @secret || @app_secret)
-      @oauth.parse_signed_request(@signed_params).should == @signed_params_result
+      expect(@oauth.parse_signed_request(@signed_params)).to eq(@signed_params_result)
     end
   end
 

--- a/spec/cases/realtime_updates_spec.rb
+++ b/spec/cases/realtime_updates_spec.rb
@@ -33,83 +33,83 @@ describe "Koala::Facebook::RealtimeUpdates" do
     # basic initialization
     it "initializes properly with an app_id and an app_access_token" do
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :app_access_token => @app_access_token)
-      updates.should be_a(Koala::Facebook::RealtimeUpdates)
+      expect(updates).to be_a(Koala::Facebook::RealtimeUpdates)
     end
 
     # attributes
     it "allows read access to app_id" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should include(:app_id)
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should_not include(:app_id=)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).to include(:app_id)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).not_to include(:app_id=)
     end
 
     it "allows read access to app_access_token" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should include(:app_access_token)
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should_not include(:app_access_token=)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).to include(:app_access_token)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).not_to include(:app_access_token=)
     end
 
     it "allows read access to secret" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should include(:secret)
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should_not include(:secret=)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).to include(:secret)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).not_to include(:secret=)
     end
 
     it "allows read access to api" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should include(:api)
-      Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym).should_not include(:api=)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).to include(:api)
+      expect(Koala::Facebook::RealtimeUpdates.instance_methods.map(&:to_sym)).not_to include(:api=)
     end
 
     # old graph_api accessor
     it "returns the api object when graph_api is called" do
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
-      updates.graph_api.should == updates.api
+      expect(updates.graph_api).to eq(updates.api)
     end
 
     it "fire a deprecation warning when graph_api is called" do
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
-      Koala::Utils.should_receive(:deprecate)
+      expect(Koala::Utils).to receive(:deprecate)
       updates.graph_api
     end
 
     # init with secret / fetching the token
     it "initializes properly with an app_id and a secret" do
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
-      updates.should be_a(Koala::Facebook::RealtimeUpdates)
+      expect(updates).to be_a(Koala::Facebook::RealtimeUpdates)
     end
 
     it "fetches an app_token from Facebook when provided an app_id and a secret" do
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
-      updates.app_access_token.should_not be_nil
+      expect(updates.app_access_token).not_to be_nil
     end
 
     it "uses the OAuth class to fetch a token when provided an app_id and a secret" do
       oauth = Koala::Facebook::OAuth.new(@app_id, @secret)
       token = oauth.get_app_access_token
-      oauth.should_receive(:get_app_access_token).and_return(token)
-      Koala::Facebook::OAuth.should_receive(:new).with(@app_id, @secret).and_return(oauth)
+      expect(oauth).to receive(:get_app_access_token).and_return(token)
+      expect(Koala::Facebook::OAuth).to receive(:new).with(@app_id, @secret).and_return(oauth)
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
     end
 
     it "sets up the with the app acces token" do
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :app_access_token => @app_access_token)
-      updates.api.should be_a(Koala::Facebook::API)
-      updates.api.access_token.should == @app_access_token
+      expect(updates.api).to be_a(Koala::Facebook::API)
+      expect(updates.api.access_token).to eq(@app_access_token)
     end
 
   end
 
   describe "#subscribe" do
     it "makes a POST to the subscription path" do
-      @updates.api.should_receive(:graph_call).with(@updates.subscription_path, anything, "post", anything)
+      expect(@updates.api).to receive(:graph_call).with(@updates.subscription_path, anything, "post", anything)
       @updates.subscribe("user", "name", @subscription_path, @verify_token)
     end
 
     it "properly formats the subscription request" do
       obj = "user"
       fields = "name"
-      @updates.api.should_receive(:graph_call).with(anything, hash_including(
+      expect(@updates.api).to receive(:graph_call).with(anything, hash_including(
         :object => obj,
         :fields => fields,
         :callback_url => @subscription_path,
@@ -122,7 +122,7 @@ describe "Koala::Facebook::RealtimeUpdates" do
       # see https://github.com/arsduo/koala/issues/150
       obj = "user"
       fields = "name"
-      @updates.api.should_not_receive(:graph_call).with(anything, hash_including(:verify_token => anything), anything, anything)
+      expect(@updates.api).not_to receive(:graph_call).with(anything, hash_including(:verify_token => anything), anything, anything)
       @updates.subscribe("user", "name", @subscription_path)
     end
 
@@ -132,7 +132,7 @@ describe "Koala::Facebook::RealtimeUpdates" do
 
     it "accepts an options hash" do
       options = {:a => 2, :b => "c"}
-      @updates.api.should_receive(:graph_call).with(anything, anything, anything, hash_including(options))
+      expect(@updates.api).to receive(:graph_call).with(anything, anything, anything, hash_including(options))
       @updates.subscribe("user", "name", @subscription_path, @verify_token, options)
     end
 
@@ -157,19 +157,19 @@ describe "Koala::Facebook::RealtimeUpdates" do
 
   describe "#unsubscribe" do
     it "makes a DELETE to the subscription path" do
-      @updates.api.should_receive(:graph_call).with(@updates.subscription_path, anything, "delete", anything)
+      expect(@updates.api).to receive(:graph_call).with(@updates.subscription_path, anything, "delete", anything)
       @updates.unsubscribe("user")
     end
 
     it "includes the object if provided" do
       obj = "user"
-      @updates.api.should_receive(:graph_call).with(anything, hash_including(:object => obj), anything, anything)
+      expect(@updates.api).to receive(:graph_call).with(anything, hash_including(:object => obj), anything, anything)
       @updates.unsubscribe(obj)
     end
 
     it "accepts an options hash" do
       options = {:a => 2, :b => "C"}
-      @updates.api.should_receive(:graph_call).with(anything, anything, anything, hash_including(options))
+      expect(@updates.api).to receive(:graph_call).with(anything, anything, anything, hash_including(options))
       @updates.unsubscribe("user", options)
     end
 
@@ -190,26 +190,26 @@ describe "Koala::Facebook::RealtimeUpdates" do
 
   describe "#list_subscriptions" do
     it "GETs the subscription path" do
-      @updates.api.should_receive(:graph_call).with(@updates.subscription_path, anything, "get", anything)
+      expect(@updates.api).to receive(:graph_call).with(@updates.subscription_path, anything, "get", anything)
       @updates.list_subscriptions
     end
 
     it "accepts options" do
       options = {:a => 3, :b => "D"}
-      @updates.api.should_receive(:graph_call).with(anything, anything, anything, hash_including(options))
+      expect(@updates.api).to receive(:graph_call).with(anything, anything, anything, hash_including(options))
       @updates.list_subscriptions(options)
     end
 
     describe "in practice" do
       it "lists subscriptions properly" do
-        @updates.list_subscriptions.should be_a(Array)
+        expect(@updates.list_subscriptions).to be_a(Array)
       end
     end
   end
 
   describe "#subscription_path" do
     it "returns the app_id/subscriptions" do
-      @updates.subscription_path.should == "#{@app_id}/subscriptions"
+      expect(@updates.subscription_path).to eq("#{@app_id}/subscriptions")
     end
   end
 
@@ -222,23 +222,23 @@ describe "Koala::Facebook::RealtimeUpdates" do
     end
 
     it "returns false if there is no X-Hub-Signature header" do
-      @updates.validate_update("", {}).should be_falsy
+      expect(@updates.validate_update("", {})).to be_falsy
     end
 
     it "returns false if the signature doesn't match the body" do
-      @updates.validate_update("", {"X-Hub-Signature" => "sha1=badsha1"}).should be false
+      expect(@updates.validate_update("", {"X-Hub-Signature" => "sha1=badsha1"})).to be false
     end
 
     it "results true if the signature matches the body with the secret" do
       body = "BODY"
       signature = OpenSSL::HMAC.hexdigest('sha1', @secret, body).chomp
-      @updates.validate_update(body, {"X-Hub-Signature" => "sha1=#{signature}"}).should be true
+      expect(@updates.validate_update(body, {"X-Hub-Signature" => "sha1=#{signature}"})).to be true
     end
 
     it "results true with alternate HTTP_X_HUB_SIGNATURE header" do
       body = "BODY"
       signature = OpenSSL::HMAC.hexdigest('sha1', @secret, body).chomp
-      @updates.validate_update(body, {"HTTP_X_HUB_SIGNATURE" => "sha1=#{signature}"}).should be true
+      expect(@updates.validate_update(body, {"HTTP_X_HUB_SIGNATURE" => "sha1=#{signature}"})).to be true
     end
 
   end
@@ -246,19 +246,19 @@ describe "Koala::Facebook::RealtimeUpdates" do
   describe ".meet_challenge" do
     it "returns false if hub.mode isn't subscribe" do
       params = {'hub.mode' => 'not subscribe'}
-      Koala::Facebook::RealtimeUpdates.meet_challenge(params).should be false
+      expect(Koala::Facebook::RealtimeUpdates.meet_challenge(params)).to be false
     end
 
     it "doesn't evaluate the block if hub.mode isn't subscribe" do
       params = {'hub.mode' => 'not subscribe'}
       block_evaluated = false
       Koala::Facebook::RealtimeUpdates.meet_challenge(params){|token| block_evaluated = true}
-      block_evaluated.should be false
+      expect(block_evaluated).to be false
     end
 
     it "returns false if not given a verify_token or block" do
       params = {'hub.mode' => 'subscribe'}
-      Koala::Facebook::RealtimeUpdates.meet_challenge(params).should be false
+      expect(Koala::Facebook::RealtimeUpdates.meet_challenge(params)).to be false
     end
 
     describe "and mode is 'subscribe'" do
@@ -273,12 +273,12 @@ describe "Koala::Facebook::RealtimeUpdates" do
         end
 
         it "returns false if the given verify token doesn't match" do
-          Koala::Facebook::RealtimeUpdates.meet_challenge(@params, @token + '1').should be false
+          expect(Koala::Facebook::RealtimeUpdates.meet_challenge(@params, @token + '1')).to be false
         end
 
         it "returns the challenge if the given verify token matches" do
           @params['hub.challenge'] = 'challenge val'
-          Koala::Facebook::RealtimeUpdates.meet_challenge(@params, @token).should == @params['hub.challenge']
+          expect(Koala::Facebook::RealtimeUpdates.meet_challenge(@params, @token)).to eq(@params['hub.challenge'])
         end
       end
 
@@ -289,27 +289,27 @@ describe "Koala::Facebook::RealtimeUpdates" do
 
         it "gives the block the token as a parameter" do
           Koala::Facebook::RealtimeUpdates.meet_challenge(@params) do |token|
-            token.should == @token
+            expect(token).to eq(@token)
           end
         end
 
         it "returns false if the given block return false" do
-          Koala::Facebook::RealtimeUpdates.meet_challenge(@params) do |token|
+          expect(Koala::Facebook::RealtimeUpdates.meet_challenge(@params) do |token|
             false
-          end.should be false
+          end).to be false
         end
 
         it "returns false if the given block returns nil" do
-          Koala::Facebook::RealtimeUpdates.meet_challenge(@params) do |token|
+          expect(Koala::Facebook::RealtimeUpdates.meet_challenge(@params) do |token|
             nil
-          end.should be false
+          end).to be false
         end
 
         it "returns the challenge if the given block returns true" do
           @params['hub.challenge'] = 'challenge val'
-          Koala::Facebook::RealtimeUpdates.meet_challenge(@params) do |token|
+          expect(Koala::Facebook::RealtimeUpdates.meet_challenge(@params) do |token|
             true
-          end.should be_truthy
+          end).to be_truthy
         end
       end
     end

--- a/spec/cases/test_users_spec.rb
+++ b/spec/cases/test_users_spec.rb
@@ -31,57 +31,57 @@ describe "Koala::Facebook::TestUsers" do
     # basic initialization
     it "initializes properly with an app_id and an app_access_token" do
       test_users = Koala::Facebook::TestUsers.new(:app_id => @app_id, :app_access_token => @app_access_token)
-      test_users.should be_a(Koala::Facebook::TestUsers)
+      expect(test_users).to be_a(Koala::Facebook::TestUsers)
     end
 
     # init with secret / fetching the token
     it "initializes properly with an app_id and a secret" do
       test_users = Koala::Facebook::TestUsers.new(:app_id => @app_id, :secret => @secret)
-      test_users.should be_a(Koala::Facebook::TestUsers)
+      expect(test_users).to be_a(Koala::Facebook::TestUsers)
     end
 
     it "uses the OAuth class to fetch a token when provided an app_id and a secret" do
       oauth = Koala::Facebook::OAuth.new(@app_id, @secret)
       token = oauth.get_app_access_token
-      oauth.should_receive(:get_app_access_token).and_return(token)
-      Koala::Facebook::OAuth.should_receive(:new).with(@app_id, @secret).and_return(oauth)
+      expect(oauth).to receive(:get_app_access_token).and_return(token)
+      expect(Koala::Facebook::OAuth).to receive(:new).with(@app_id, @secret).and_return(oauth)
       test_users = Koala::Facebook::TestUsers.new(:app_id => @app_id, :secret => @secret)
     end
 
     # attributes
     it "allows read access to app_id, app_access_token, and secret" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should include(:app_id)
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should_not include(:app_id=)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).to include(:app_id)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).not_to include(:app_id=)
     end
 
     it "allows read access to app_access_token" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should include(:app_access_token)
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should_not include(:app_access_token=)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).to include(:app_access_token)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).not_to include(:app_access_token=)
     end
 
     it "allows read access to secret" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should include(:secret)
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should_not include(:secret=)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).to include(:secret)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).not_to include(:secret=)
     end
 
     it "allows read access to api" do
       # in Ruby 1.9, .method returns symbols
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should include(:api)
-      Koala::Facebook::TestUsers.instance_methods.map(&:to_sym).should_not include(:api=)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).to include(:api)
+      expect(Koala::Facebook::TestUsers.instance_methods.map(&:to_sym)).not_to include(:api=)
     end
 
     # old graph_api accessor
     it "returns the api object when graph_api is called" do
       test_users = Koala::Facebook::TestUsers.new(:app_id => @app_id, :secret => @secret)
-      test_users.graph_api.should == test_users.api
+      expect(test_users.graph_api).to eq(test_users.api)
     end
 
     it "fire a deprecation warning when graph_api is called" do
       test_users = Koala::Facebook::TestUsers.new(:app_id => @app_id, :secret => @secret)
-      Koala::Utils.should_receive(:deprecate)
+      expect(Koala::Utils).to receive(:deprecate)
       test_users.graph_api
     end
   end
@@ -93,43 +93,43 @@ describe "Koala::Facebook::TestUsers" do
       it "creates a test user when not given installed" do
         result = @test_users.create(false)
         @user1 = result["id"]
-        result.should be_a(Hash)
-        (result["id"] && result["access_token"] && result["login_url"]).should
+        expect(result).to be_a(Hash)
+        expect(result["id"] && result["access_token"] && result["login_url"]).to be_truthy
       end
 
       it "creates a test user when not given installed, ignoring permissions" do
         result = @test_users.create(false, "read_stream")
         @user1 = result["id"]
-        result.should be_a(Hash)
-        (result["id"] && result["access_token"] && result["login_url"]).should
+        expect(result).to be_a(Hash)
+        expect(result["id"] && result["access_token"] && result["login_url"]).to be_truthy
       end
 
       it "accepts permissions as a string" do
-        @test_users.graph_api.should_receive(:graph_call).with(anything, hash_including("permissions" => "read_stream,publish_stream"), anything, anything)
+        expect(@test_users.graph_api).to receive(:graph_call).with(anything, hash_including("permissions" => "read_stream,publish_stream"), anything, anything)
         result = @test_users.create(true, "read_stream,publish_stream")
       end
 
       it "accepts permissions as an array" do
-        @test_users.graph_api.should_receive(:graph_call).with(anything, hash_including("permissions" => "read_stream,publish_stream"), anything, anything)
+        expect(@test_users.graph_api).to receive(:graph_call).with(anything, hash_including("permissions" => "read_stream,publish_stream"), anything, anything)
         result = @test_users.create(true, ["read_stream", "publish_stream"])
       end
 
       it "creates a test user when given installed and a permission" do
         result = @test_users.create(true, "read_stream")
         @user1 = result["id"]
-        result.should be_a(Hash)
-        (result["id"] && result["access_token"] && result["login_url"]).should
+        expect(result).to be_a(Hash)
+        expect(result["id"] && result["access_token"] && result["login_url"]).to be_truthy
       end
 
       it "lets you specify other graph arguments, like uid and access token" do
         args = {:uid => "some test user ID", :owner_access_token => "some owner access token"}
-        @test_users.graph_api.should_receive(:graph_call).with(anything, hash_including(args), anything, anything)
+        expect(@test_users.graph_api).to receive(:graph_call).with(anything, hash_including(args), anything, anything)
         @test_users.create(true, nil, args)
       end
 
       it "lets you specify http options that get passed through to the graph call" do
         options = {:some_http_option => true}
-        @test_users.graph_api.should_receive(:graph_call).with(anything, anything, anything, options)
+        expect(@test_users.graph_api).to receive(:graph_call).with(anything, anything, anything, options)
         @test_users.create(true, nil, {}, options)
       end
     end
@@ -142,16 +142,16 @@ describe "Koala::Facebook::TestUsers" do
 
       it "lists test users" do
         result = @test_users.list
-        result.should be_an(Array)
+        expect(result).to be_an(Array)
         first_user, second_user = result[0], result[1]
-        (first_user["id"] && first_user["access_token"] && first_user["login_url"]).should
-        (second_user["id"] && second_user["access_token"] && second_user["login_url"]).should
+        expect(first_user["id"] && first_user["access_token"] && first_user["login_url"]).to be_truthy
+        expect(second_user["id"] && second_user["access_token"] && second_user["login_url"]).to be_truthy
       end
 
       it "accepts http options" do
         @stubbed = true
         options = {:some_http_option => true}
-        @test_users.api.should_receive(:graph_call).with(anything, anything, anything, options)
+        expect(@test_users.api).to receive(:graph_call).with(anything, anything, anything, options)
         @test_users.list(options)
       end
     end
@@ -163,24 +163,24 @@ describe "Koala::Facebook::TestUsers" do
       end
 
       it "deletes a user by id" do
-        @test_users.delete(@user1['id']).should be true
+        expect(@test_users.delete(@user1['id'])).to be true
         @user1 = nil
       end
 
       it "deletes a user by hash" do
-        @test_users.delete(@user2).should be true
+        expect(@test_users.delete(@user2)).to be true
         @user2 = nil
       end
 
       it "does not delete users when provided a false ID" do
-        lambda { @test_users.delete("#{@user1['id']}1") }.should raise_exception(Koala::Facebook::APIError)
+        expect { @test_users.delete("#{@user1['id']}1") }.to raise_exception(Koala::Facebook::APIError)
       end
 
       it "lets you specify http options that get passed through to the graph call" do
         options = {:some_http_option => true}
         # technically this goes through delete_object, but this makes it less brittle
         @stubbed = true
-        @test_users.graph_api.should_receive(:graph_call).with(anything, anything, anything, options)
+        expect(@test_users.graph_api).to receive(:graph_call).with(anything, anything, anything, options)
         @test_users.delete("user", options)
       end
     end
@@ -188,24 +188,24 @@ describe "Koala::Facebook::TestUsers" do
     describe "#delete_all" do
       it "deletes the batch API to deleten all users found by the list commnand" do
         array = 200.times.collect { {"id" => rand}}
-        @test_users.should_receive(:list).and_return(array, [])
+        expect(@test_users).to receive(:list).and_return(array, [])
         batch_api = double("batch API")
         allow(@test_users.api).to receive(:batch).and_yield(batch_api)
-        array.each {|item| batch_api.should_receive(:delete_object).with(item["id"]) }
+        array.each {|item| expect(batch_api).to receive(:delete_object).with(item["id"]) }
         @test_users.delete_all
       end
 
       it "accepts http options that get passed to both list and the batch call" do
         options = {:some_http_option => true}
-        @test_users.should_receive(:list).with(options).and_return([{"id" => rand}], [])
-        @test_users.api.should_receive(:batch).with(options)
+        expect(@test_users).to receive(:list).with(options).and_return([{"id" => rand}], [])
+        expect(@test_users.api).to receive(:batch).with(options)
         @test_users.delete_all(options)
       end
 
       it "breaks if Facebook sends back the same list twice" do
         list = [{"id" => rand}]
         allow(@test_users).to receive(:list).and_return(list)
-        @test_users.api.should_receive(:batch).once
+        expect(@test_users.api).to receive(:batch).once
         @test_users.delete_all
       end
 
@@ -213,7 +213,7 @@ describe "Koala::Facebook::TestUsers" do
         list1 = [{"id" => 123}]
         list2 = [{"id" => 123, "name" => "foo"}]
         allow(@test_users).to receive(:list).twice.and_return(list1, list2)
-        @test_users.api.should_receive(:batch).once
+        expect(@test_users.api).to receive(:batch).once
         @test_users.delete_all
       end
     end
@@ -227,20 +227,20 @@ describe "Koala::Facebook::TestUsers" do
 
       it "makes a POST with the test user Graph API " do
         @user1 = @test_users2.create(true)
-        @test_users2.graph_api.should_receive(:graph_call).with(anything, anything, "post", anything)
+        expect(@test_users2.graph_api).to receive(:graph_call).with(anything, anything, "post", anything)
         @test_users2.update(@user1, @updates)
       end
 
       it "makes a request to the test user with the update params " do
         @user1 = @test_users2.create(true)
-        @test_users2.graph_api.should_receive(:graph_call).with(@user1["id"], @updates, anything, anything)
+        expect(@test_users2.graph_api).to receive(:graph_call).with(@user1["id"], @updates, anything, anything)
         @test_users2.update(@user1, @updates)
       end
 
       it "accepts an options hash" do
         options = {:some_http_option => true}
         @stubbed = true
-        @test_users2.graph_api.should_receive(:graph_call).with(anything, anything, anything, options)
+        expect(@test_users2.graph_api).to receive(:graph_call).with(anything, anything, anything, options)
         @test_users2.update("foo", @updates, options)
       end
 
@@ -248,7 +248,7 @@ describe "Koala::Facebook::TestUsers" do
         @user1 = @test_users.create(true)
         @test_users.update(@user1, @updates)
         user_info = Koala::Facebook::API.new(@user1["access_token"]).get_object(@user1["id"])
-        user_info["name"].should == @updates[:name]
+        expect(user_info["name"]).to eq(@updates[:name])
       end
     end
 
@@ -260,7 +260,7 @@ describe "Koala::Facebook::TestUsers" do
 
       it "makes two users into friends with string hashes" do
         result = @test_users.befriend(@user1, @user2)
-        result.should be true
+        expect(result).to be true
       end
 
       it "makes two users into friends with symbol hashes" do
@@ -270,18 +270,18 @@ describe "Koala::Facebook::TestUsers" do
         @user2.each_pair {|k, v| new_user_2[k.to_sym] = v}
 
         result = @test_users.befriend(new_user_1, new_user_2)
-        result.should be true
+        expect(result).to be true
       end
 
       it "does not accept user IDs anymore" do
-        lambda { @test_users.befriend(@user1["id"], @user2["id"]) }.should raise_exception
+        expect { @test_users.befriend(@user1["id"], @user2["id"]) }.to raise_exception
       end
 
       it "accepts http options passed to both calls" do
         options = {:some_http_option => true}
         # should come twice, once for each user
         @stubbed = true
-        Koala.http_service.should_receive(:make_request).with(anything, anything, anything, options).twice.and_return(Koala::HTTPService::Response.new(200, "{}", {}))
+        expect(Koala.http_service).to receive(:make_request).with(anything, anything, anything, options).twice.and_return(Koala::HTTPService::Response.new(200, "{}", {}))
         @test_users.befriend(@user1, @user2, options)
       end
     end
@@ -289,7 +289,7 @@ describe "Koala::Facebook::TestUsers" do
 
   describe "#test_user_accounts_path" do
     it "returns the app_id/accounts/test-users" do
-      @test_users.test_user_accounts_path.should == "/#{@app_id}/accounts/test-users"
+      expect(@test_users.test_user_accounts_path).to eq("/#{@app_id}/accounts/test-users")
     end
   end
 
@@ -299,12 +299,12 @@ describe "Koala::Facebook::TestUsers" do
 
       if KoalaTest.mock_interface?
         id_counter = 999999900
-        @test_users.stub(:create).and_return do
+        allow(@test_users).to receive(:create).and_return do
           id_counter += 1
           {"id" => id_counter, "access_token" => @token, "login_url" => "https://www.facebook.com/platform/test_account.."}
         end
-        @test_users.stub(:befriend).and_return(true)
-        @test_users.stub(:delete).and_return(true)
+        allow(@test_users).to receive(:befriend).and_return(true)
+        allow(@test_users).to receive(:delete).and_return(true)
       end
     end
 
@@ -312,15 +312,15 @@ describe "Koala::Facebook::TestUsers" do
       it "creates a 5 person network" do
         size = 5
         @network = @test_users.create_network(size)
-        @network.should be_a(Array)
-        @network.size.should == size
+        expect(@network).to be_a(Array)
+        expect(@network.size).to eq(size)
       end
     end
 
     it "has no built-in network size limit" do
       times = 100
-      @test_users.should_receive(:create).exactly(times).times
-      @test_users.stub(:befriend)
+      expect(@test_users).to receive(:create).exactly(times).times
+      allow(@test_users).to receive(:befriend)
       @test_users.create_network(times)
     end
 
@@ -328,17 +328,17 @@ describe "Koala::Facebook::TestUsers" do
       perms = ["read_stream", "offline_access"]
       installed = false
       count = 25
-      @test_users.should_receive(:create).exactly(count).times.with(installed, perms, anything)
-      @test_users.stub(:befriend)
+      expect(@test_users).to receive(:create).exactly(count).times.with(installed, perms, anything)
+      allow(@test_users).to receive(:befriend)
       @test_users.create_network(count, installed, perms)
     end
 
     it "accepts http options that are passed to both the create and befriend calls" do
       count = 25
       options = {:some_http_option => true}
-      @test_users.should_receive(:create).exactly(count).times.with(anything, anything, options).and_return({})
+      expect(@test_users).to receive(:create).exactly(count).times.with(anything, anything, options).and_return({})
       # there are more befriends than creates, but we don't need to do the extra work to calculate out the exact #
-      @test_users.should_receive(:befriend).at_least(count).times.with(anything, anything, options)
+      expect(@test_users).to receive(:befriend).at_least(count).times.with(anything, anything, options)
       @test_users.create_network(count, true, "", options)
     end
   end # when creating network

--- a/spec/cases/uploadable_io_spec.rb
+++ b/spec/cases/uploadable_io_spec.rb
@@ -16,7 +16,7 @@ describe "Koala::UploadableIO" do
       :tempfile => tempfile,
       :original_filename => "bar"
     )
-    tempfile.stub(:respond_to?).with(:path).and_return(true)
+    allow(tempfile).to receive(:respond_to?).with(:path).and_return(true)
 
     [tempfile, uploaded_file]
   end
@@ -39,15 +39,15 @@ describe "Koala::UploadableIO" do
         end
 
         it "returns an UploadIO with the same file path" do
-          Koala::UploadableIO.new(*@koala_io_params).io_or_path.should == @path
+          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@path)
         end
 
         it "returns an UploadIO with the same content type" do
-          Koala::UploadableIO.new(*@koala_io_params).content_type.should == @stub_type
+          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(@stub_type)
         end
 
         it "returns an UploadIO with the file's name" do
-          Koala::UploadableIO.new(*@koala_io_params).filename.should == File.basename(@path)
+          expect(Koala::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@path))
         end
       end
 
@@ -68,16 +68,16 @@ describe "Koala::UploadableIO" do
         end
 
         it "returns an UploadIO with the same io" do
-          Koala::UploadableIO.new(*@koala_io_params).io_or_path.should == @koala_io_params[0]
+          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@koala_io_params[0])
         end
 
         it "returns an UploadableIO with the same content_type" do
           content_stub = @koala_io_params[1] = double('Content Type')
-          Koala::UploadableIO.new(*@koala_io_params).content_type.should == content_stub
+          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
         end
 
         it "returns an UploadableIO with the right filename" do
-          Koala::UploadableIO.new(*@koala_io_params).filename.should == File.basename(@file.path)
+          expect(Koala::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@file.path))
         end
       end
 
@@ -100,16 +100,16 @@ describe "Koala::UploadableIO" do
 
         it "returns an UploadIO with the same io" do
           #Problem comparing Tempfile in Ruby 1.8, REE and Rubinius mode 1.8
-          Koala::UploadableIO.new(*@koala_io_params).io_or_path.path.should == @koala_io_params[0].path
+          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path.path).to eq(@koala_io_params[0].path)
         end
 
         it "returns an UploadableIO with the same content_type" do
           content_stub = @koala_io_params[1] = double('Content Type')
-          Koala::UploadableIO.new(*@koala_io_params).content_type.should == content_stub
+          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
         end
 
         it "returns an UploadableIO with the right filename" do
-          Koala::UploadableIO.new(*@koala_io_params).filename.should == File.basename(@file.path)
+          expect(Koala::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@file.path))
         end
       end
 
@@ -130,18 +130,18 @@ describe "Koala::UploadableIO" do
         end
 
         it "returns an UploadableIO with the same io" do
-          Koala::UploadableIO.new(*@koala_io_params).io_or_path.should == @koala_io_params[0]
+          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@koala_io_params[0])
         end
 
         it "returns an UploadableIO with the same content_type" do
           content_stub = @koala_io_params[1] = double('Content Type')
-          Koala::UploadableIO.new(*@koala_io_params).content_type.should == content_stub
+          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
         end
       end
 
       describe "and no content type" do
         it "raises an exception" do
-          lambda { Koala::UploadableIO.new(*@koala_io_params) }.should raise_exception(Koala::KoalaError)
+          expect { Koala::UploadableIO.new(*@koala_io_params) }.to raise_exception(Koala::KoalaError)
         end
       end
     end
@@ -153,18 +153,18 @@ describe "Koala::UploadableIO" do
 
       it "gets the path from the tempfile associated with the UploadedFile" do
         expected_path = double('Tempfile')
-        @tempfile.should_receive(:path).and_return(expected_path)
-        Koala::UploadableIO.new(@uploaded_file).io_or_path.should == expected_path
+        expect(@tempfile).to receive(:path).and_return(expected_path)
+        expect(Koala::UploadableIO.new(@uploaded_file).io_or_path).to eq(expected_path)
       end
 
       it "gets the content type via the content_type method" do
         expected_content_type = double('Content Type')
-        @uploaded_file.should_receive(:content_type).and_return(expected_content_type)
-        Koala::UploadableIO.new(@uploaded_file).content_type.should == expected_content_type
+        expect(@uploaded_file).to receive(:content_type).and_return(expected_content_type)
+        expect(Koala::UploadableIO.new(@uploaded_file).content_type).to eq(expected_content_type)
       end
 
       it "gets the filename from the UploadedFile" do
-        Koala::UploadableIO.new(@uploaded_file).filename.should == @uploaded_file.original_filename
+        expect(Koala::UploadableIO.new(@uploaded_file).filename).to eq(@uploaded_file.original_filename)
       end
     end
 
@@ -178,7 +178,7 @@ describe "Koala::UploadableIO" do
         @file_hash[:tempfile] = expected_file
 
         uploadable = Koala::UploadableIO.new(@file_hash)
-        uploadable.io_or_path.should == expected_file
+        expect(uploadable.io_or_path).to eq(expected_file)
       end
 
       it "gets the content type from the :type key" do
@@ -186,12 +186,12 @@ describe "Koala::UploadableIO" do
         @file_hash[:type] = expected_content_type
 
         uploadable = Koala::UploadableIO.new(@file_hash)
-        uploadable.content_type.should == expected_content_type
+        expect(uploadable.content_type).to eq(expected_content_type)
       end
 
       it "gets the content type from the :type key" do
         uploadable = Koala::UploadableIO.new(@file_hash)
-        uploadable.filename.should == @file_hash[:filename]
+        expect(uploadable.filename).to eq(@file_hash[:filename])
       end
     end
 
@@ -199,12 +199,12 @@ describe "Koala::UploadableIO" do
       # what that means is tested below
       it "should accept a file object alone" do
         params = [BEACH_BALL_PATH]
-        lambda { Koala::UploadableIO.new(*params) }.should_not raise_exception
+        expect { Koala::UploadableIO.new(*params) }.not_to raise_exception
       end
 
       it "should accept a file path alone" do
         params = [BEACH_BALL_PATH]
-        lambda { Koala::UploadableIO.new(*params) }.should_not raise_exception
+        expect { Koala::UploadableIO.new(*params) }.not_to raise_exception
       end
     end
   end
@@ -212,20 +212,20 @@ describe "Koala::UploadableIO" do
   describe "getting an UploadableIO" do
     before(:each) do
       @upload_io = double("UploadIO")
-      UploadIO.stub(:new).with(anything, anything, anything).and_return(@upload_io)
+      allow(UploadIO).to receive(:new).with(anything, anything, anything).and_return(@upload_io)
     end
 
     context "if no filename was provided" do
       it "should call the constructor with the content type, file name, and a dummy file name" do
-        UploadIO.should_receive(:new).with(BEACH_BALL_PATH, "content/type", anything).and_return(@upload_io)
-        Koala::UploadableIO.new(BEACH_BALL_PATH, "content/type").to_upload_io.should == @upload_io
+        expect(UploadIO).to receive(:new).with(BEACH_BALL_PATH, "content/type", anything).and_return(@upload_io)
+        expect(Koala::UploadableIO.new(BEACH_BALL_PATH, "content/type").to_upload_io).to eq(@upload_io)
       end
     end
 
     context "if a filename was provided" do
       it "should call the constructor with the content type, file name, and the filename" do
         filename = "file"
-        UploadIO.should_receive(:new).with(BEACH_BALL_PATH, "content/type", filename).and_return(@upload_io)
+        expect(UploadIO).to receive(:new).with(BEACH_BALL_PATH, "content/type", filename).and_return(@upload_io)
         Koala::UploadableIO.new(BEACH_BALL_PATH, "content/type", filename).to_upload_io
       end
     end
@@ -234,33 +234,33 @@ describe "Koala::UploadableIO" do
   describe "getting a file" do
     it "returns the File if initialized with a file" do
       f = File.new(BEACH_BALL_PATH)
-      Koala::UploadableIO.new(f).to_file.should == f
+      expect(Koala::UploadableIO.new(f).to_file).to eq(f)
     end
 
     it "should open up and return a file corresponding to the path if io_or_path is a path" do
       result = double("File")
-      File.should_receive(:open).with(BEACH_BALL_PATH).and_return(result)
-      Koala::UploadableIO.new(BEACH_BALL_PATH).to_file.should == result
+      expect(File).to receive(:open).with(BEACH_BALL_PATH).and_return(result)
+      expect(Koala::UploadableIO.new(BEACH_BALL_PATH).to_file).to eq(result)
     end
   end
 
   describe ".binary_content?" do
     it "returns true for Rails 3 file uploads" do
-      Koala::UploadableIO.binary_content?(rails_3_mocks.last).should be_truthy
+      expect(Koala::UploadableIO.binary_content?(rails_3_mocks.last)).to be_truthy
     end
 
     it "returns true for Sinatra file uploads" do
-      Koala::UploadableIO.binary_content?(rails_3_mocks.last).should be_truthy
+      expect(Koala::UploadableIO.binary_content?(rails_3_mocks.last)).to be_truthy
     end
 
     it "returns true for File objects" do
-      Koala::UploadableIO.binary_content?(File.open(BEACH_BALL_PATH)).should be_truthy
+      expect(Koala::UploadableIO.binary_content?(File.open(BEACH_BALL_PATH))).to be_truthy
     end
 
     it "returns false for everything else" do
-      Koala::UploadableIO.binary_content?(StringIO.new).should be_falsy
-      Koala::UploadableIO.binary_content?(BEACH_BALL_PATH).should be_falsy
-      Koala::UploadableIO.binary_content?(nil).should be_falsy
+      expect(Koala::UploadableIO.binary_content?(StringIO.new)).to be_falsy
+      expect(Koala::UploadableIO.binary_content?(BEACH_BALL_PATH)).to be_falsy
+      expect(Koala::UploadableIO.binary_content?(nil)).to be_falsy
     end
   end
 end  # describe UploadableIO

--- a/spec/cases/utils_spec.rb
+++ b/spec/cases/utils_spec.rb
@@ -4,29 +4,29 @@ describe Koala::Utils do
   describe ".deprecate" do    
     before :each do
       # unstub deprecate so we can test it
-      Koala::Utils.unstub(:deprecate)
+       allow(Koala::Utils).to receive(:deprecate).and_call_original
     end
     
     it "has a deprecation prefix that includes the words Koala and deprecation" do
-      Koala::Utils::DEPRECATION_PREFIX.should =~ /koala/i
-      Koala::Utils::DEPRECATION_PREFIX.should =~ /deprecation/i      
+      expect(Koala::Utils::DEPRECATION_PREFIX).to match(/koala/i)
+      expect(Koala::Utils::DEPRECATION_PREFIX).to match(/deprecation/i)      
     end
     
     it "prints a warning with Kernel.warn" do
       message = Time.now.to_s + rand.to_s
-      Kernel.should_receive(:warn)
+      expect(Kernel).to receive(:warn)
       Koala::Utils.deprecate(message)
     end
 
     it "prints the deprecation prefix and the warning" do
       message = Time.now.to_s + rand.to_s
-      Kernel.should_receive(:warn).with(Koala::Utils::DEPRECATION_PREFIX + message)
+      expect(Kernel).to receive(:warn).with(Koala::Utils::DEPRECATION_PREFIX + message)
       Koala::Utils.deprecate(message)
     end
     
     it "only prints each unique message once" do
       message = Time.now.to_s + rand.to_s
-      Kernel.should_receive(:warn).once
+      expect(Kernel).to receive(:warn).once
       Koala::Utils.deprecate(message)
       Koala::Utils.deprecate(message)
     end
@@ -34,20 +34,20 @@ describe Koala::Utils do
   
   describe ".logger" do
     it "has an accessor for logger" do
-      Koala::Utils.methods.map(&:to_sym).should include(:logger)
-      Koala::Utils.methods.map(&:to_sym).should include(:logger=)
+      expect(Koala::Utils.methods.map(&:to_sym)).to include(:logger)
+      expect(Koala::Utils.methods.map(&:to_sym)).to include(:logger=)
     end
     
     it "defaults to the standard ruby logger with level set to ERROR" do |variable|
-      Koala::Utils.logger.should be_kind_of(Logger)
-      Koala::Utils.logger.level.should == Logger::ERROR
+      expect(Koala::Utils.logger).to be_kind_of(Logger)
+      expect(Koala::Utils.logger.level).to eq(Logger::ERROR)
     end
     
     logger_methods = [:debug, :info, :warn, :error, :fatal]
     
     logger_methods.each do |logger_method|
       it "should delegate #{logger_method} to the attached logger" do
-        Koala::Utils.logger.should_receive(logger_method)
+        expect(Koala::Utils.logger).to receive(logger_method)
         Koala::Utils.send(logger_method, "Test #{logger_method} message")
       end
     end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -7,14 +7,14 @@ RSpec::Matchers.define :match_url do |url|
     original_query_hash = query_to_params(original_query_string)
 
     # the base URLs need to match
-    base.should == original_base
+    expect(base).to eq(original_base)
     
     # the number of parameters should match (avoid one being a subset of the other)
-    query_hash.values.length.should == original_query_hash.values.length
+    expect(query_hash.values.length).to eq(original_query_hash.values.length)
     
     # and ensure all the keys and values match
     query_hash.each_pair do |key, value|
-      original_query_hash[key].should == value
+      expect(original_query_hash[key]).to eq(value)
     end
   end
   

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -3,7 +3,7 @@ shared_examples_for "Koala GraphAPI" do
 
   # API
   it "never uses the rest api server" do
-    Koala.should_receive(:make_request).with(
+    expect(Koala).to receive(:make_request).with(
       anything,
       anything,
       anything,
@@ -17,41 +17,41 @@ shared_examples_for "Koala GraphAPI" do
   describe "graph_call" do
     it "passes all arguments to the api method" do
       args = [KoalaTest.user1, {}, "get", {:a => :b}]
-      @api.should_receive(:api).with(*args)
+      expect(@api).to receive(:api).with(*args)
       @api.graph_call(*args)
     end
 
     it "throws an APIError if the result hash has an error key" do
-      Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(500, '{"error": "An error occurred!"}', {}))
-      lambda { @api.graph_call(KoalaTest.user1, {}) }.should raise_exception(Koala::Facebook::APIError)
+      allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(500, '{"error": "An error occurred!"}', {}))
+      expect { @api.graph_call(KoalaTest.user1, {}) }.to raise_exception(Koala::Facebook::APIError)
     end
 
     it "passes the results through GraphCollection.evaluate" do
       result = {}
-      @api.stub(:api).and_return(result)
-      Koala::Facebook::GraphCollection.should_receive(:evaluate).with(result, @api)
+      allow(@api).to receive(:api).and_return(result)
+      expect(Koala::Facebook::GraphCollection).to receive(:evaluate).with(result, @api)
       @api.graph_call("/me")
     end
 
     it "returns the results of GraphCollection.evaluate" do
       expected = {}
-      @api.stub(:api).and_return([])
-      Koala::Facebook::GraphCollection.should_receive(:evaluate).and_return(expected)
-      @api.graph_call("/me").should == expected
+      allow(@api).to receive(:api).and_return([])
+      expect(Koala::Facebook::GraphCollection).to receive(:evaluate).and_return(expected)
+      expect(@api.graph_call("/me")).to eq(expected)
     end
 
     it "returns the post_processing block's results if one is supplied" do
       other_result = [:a, 2, :three]
       block = Proc.new {|r| other_result}
-      @api.stub(:api).and_return({})
-      @api.graph_call("/me", {}, "get", {}, &block).should == other_result
+      allow(@api).to receive(:api).and_return({})
+      expect(@api.graph_call("/me", {}, "get", {}, &block)).to eq(other_result)
     end
   end
 
   # SEARCH
   it "can search" do
     result = @api.search("facebook")
-    result.length.should be_an(Integer)
+    expect(result.length).to be_an(Integer)
   end
 
   # DATA
@@ -61,71 +61,71 @@ shared_examples_for "Koala GraphAPI" do
   it "gets public data about a user" do
     result = @api.get_object(KoalaTest.user1)
     # the results should have an ID and a name, among other things
-    (result["id"] && result["name"]).should_not be_nil
+    expect(result["id"] && result["name"]).not_to be_nil
   end
 
   it "gets public data about a Page" do
     result = @api.get_object(KoalaTest.page)
     # the results should have an ID and a name, among other things
-    (result["id"] && result["name"]).should
+    expect(result["id"] && result["name"]).to be_truthy
   end
 
   it "returns [] from get_objects if passed an empty array" do
     results = @api.get_objects([])
-    results.should == []
+    expect(results).to eq([])
   end
 
   it "gets multiple objects" do
     results = @api.get_objects([KoalaTest.page, KoalaTest.user1])
-    results.size.should eq(2)
+    expect(results.size).to eq(2)
   end
 
   it "gets multiple objects if they're a string" do
     results = @api.get_objects("facebook,#{KoalaTest.user1}")
-    results.size.should eq(2)
+    expect(results.size).to eq(2)
   end
 
   describe "#get_picture" do
     it "can access a user's picture" do
-      @api.get_picture(KoalaTest.user2).should =~ /http[s]*\:\/\//
+      expect(@api.get_picture(KoalaTest.user2)).to match(/http[s]*\:\/\//)
     end
 
     it "can access a user's picture, given a picture type"  do
-      @api.get_picture(KoalaTest.user2, {:type => 'large'}).should =~ /^http[s]*\:\/\//
+      expect(@api.get_picture(KoalaTest.user2, {:type => 'large'})).to match(/^http[s]*\:\/\//)
     end
 
     it "works even if Facebook returns nil" do
-      @api.stub(:graph_call).and_return(nil)
-      @api.get_picture(KoalaTest.user2, {:type => 'large'}).should be_nil
+      allow(@api).to receive(:graph_call).and_return(nil)
+      expect(@api.get_picture(KoalaTest.user2, {:type => 'large'})).to be_nil
     end
   end
 
   it "can access connections from public Pages" do
     result = @api.get_connections(KoalaTest.page, "photos")
-    result.should be_a(Array)
+    expect(result).to be_a(Array)
   end
 
   it "can access comments for a URL" do
     result = @api.get_comments_for_urls(["http://developers.facebook.com/blog/post/472"])
-    (result["http://developers.facebook.com/blog/post/472"]).should
+    expect(result["http://developers.facebook.com/blog/post/472"]).to be_truthy
   end
 
   it "can access comments for 2 URLs" do
     result = @api.get_comments_for_urls(["http://developers.facebook.com/blog/post/490", "http://developers.facebook.com/blog/post/472"])
-    (result["http://developers.facebook.com/blog/post/490"] && result["http://developers.facebook.com/blog/post/472"]).should
+    expect(result["http://developers.facebook.com/blog/post/490"] && result["http://developers.facebook.com/blog/post/472"]).to be_truthy
   end
 
   # SEARCH
   it "can search" do
     result = @api.search("facebook")
-    result.length.should be_an(Integer)
+    expect(result.length).to be_an(Integer)
   end
 
   # PAGING THROUGH COLLECTIONS
   # see also graph_collection_tests
   it "makes a request for a page when provided a specific set of page params" do
     query = [1, 2]
-    @api.should_receive(:graph_call).with(*query)
+    expect(@api).to receive(:graph_call).with(*query)
     @api.get_page(query)
   end
 
@@ -133,41 +133,41 @@ shared_examples_for "Koala GraphAPI" do
   it "can use the beta tier" do
     result = @api.get_object(KoalaTest.user1, {}, :beta => true)
     # the results should have an ID and a name, among other things
-    (result["id"] && result["name"]).should_not be_nil
+    expect(result["id"] && result["name"]).to be_truthy
   end
 
   # FQL
   describe "#fql_query" do
     it "makes a request to /fql" do
-      @api.should_receive(:get_object).with("fql", anything, anything)
+      expect(@api).to receive(:get_object).with("fql", anything, anything)
       @api.fql_query double('query string')
     end
 
     it "passes a query argument" do
       query = double('query string')
-      @api.should_receive(:get_object).with(anything, hash_including(:q => query), anything)
+      expect(@api).to receive(:get_object).with(anything, hash_including(:q => query), anything)
       @api.fql_query(query)
     end
 
     it "passes on any other arguments provided" do
       args = {:a => 2}
-      @api.should_receive(:get_object).with(anything, hash_including(args), anything)
+      expect(@api).to receive(:get_object).with(anything, hash_including(args), anything)
       @api.fql_query("a query", args)
     end
   end
 
   describe "#fql_multiquery" do
     it "makes a request to /fql" do
-      @api.should_receive(:get_object).with("fql", anything, anything)
+      expect(@api).to receive(:get_object).with("fql", anything, anything)
       @api.fql_multiquery 'query string'
     end
 
     it "passes a queries argument" do
       queries = double('query string')
       queries_json = "some JSON"
-      MultiJson.stub(:dump).with(queries).and_return(queries_json)
+      allow(MultiJson).to receive(:dump).with(queries).and_return(queries_json)
 
-      @api.should_receive(:get_object).with(anything, hash_including(:q => queries_json), anything)
+      expect(@api).to receive(:get_object).with(anything, hash_including(:q => queries_json), anything)
       @api.fql_multiquery(queries)
     end
 
@@ -181,14 +181,14 @@ shared_examples_for "Koala GraphAPI" do
         "query2" => [:a, :b, :c]
       }
 
-      @api.stub(:get_object).and_return(raw_results)
+      allow(@api).to receive(:get_object).and_return(raw_results)
       results = @api.fql_multiquery({:query => true})
-      results.should == expected_results
+      expect(results).to eq(expected_results)
     end
 
     it "passes on any other arguments provided" do
       args = {:a => 2}
-      @api.should_receive(:get_object).with(anything, hash_including(args), anything)
+      expect(@api).to receive(:get_object).with(anything, hash_including(args), anything)
       @api.fql_multiquery("a query", args)
     end
   end
@@ -199,28 +199,28 @@ shared_examples_for "Koala GraphAPI with an access token" do
   it "gets private data about a user" do
     result = @api.get_object(KoalaTest.user1)
     # updated_time should be a pretty fixed test case
-    result["updated_time"].should_not be_nil
+    expect(result["updated_time"]).not_to be_nil
   end
 
   it "gets data about 'me'" do
     result = @api.get_object("me")
-    result["updated_time"].should
+    expect(result["updated_time"]).to be_truthy
   end
 
   it "gets multiple objects" do
     result = @api.get_objects([KoalaTest.page, KoalaTest.user1])
-    result.length.should == 2
+    expect(result.length).to eq(2)
   end
   it "can access connections from users" do
     result = @api.get_connections(KoalaTest.user2, "friends")
-    result.length.should > 0
+    expect(result.length).to be > 0
   end
 
   # PUT
   it "can write an object to the graph" do
     result = @api.put_wall_post("Hello, world, from the test suite!")
     @temporary_object_id = result["id"]
-    @temporary_object_id.should_not be_nil
+    expect(@temporary_object_id).not_to be_nil
   end
 
   # DELETE
@@ -228,7 +228,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
     result = @api.put_wall_post("Hello, world, from the test suite delete method!")
     object_id_to_delete = result["id"]
     delete_result = @api.delete_object(object_id_to_delete)
-    delete_result.should == true
+    expect(delete_result).to eq(true)
   end
 
   it "can delete likes" do
@@ -236,7 +236,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
     @temporary_object_id = result["id"]
     @api.put_like(@temporary_object_id)
     delete_like_result = @api.delete_like(@temporary_object_id)
-    delete_like_result.should == true
+    expect(delete_like_result).to eq(true)
   end
 
   # additional put tests
@@ -247,13 +247,13 @@ shared_examples_for "Koala GraphAPI with an access token" do
     get_result = @api.get_object(@temporary_object_id)
 
     # make sure the message we sent is the message that got posted
-    get_result["message"].should == message
+    expect(get_result["message"]).to eq(message)
   end
 
   it "can post a message with an attachment to a feed" do
     result = @api.put_wall_post("Hello, world, from the test suite again!", {:name => "OAuth Playground", :link => "http://oauth.twoalex.com/"})
     @temporary_object_id = result["id"]
-    @temporary_object_id.should_not be_nil
+    expect(@temporary_object_id).not_to be_nil
   end
 
   it "can post a message whose attachment has a properties dictionary" do
@@ -271,11 +271,11 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
     result = @api.put_wall_post("body", args)
     @temporary_object_id = result["id"]
-    @temporary_object_id.should_not be_nil
+    expect(@temporary_object_id).not_to be_nil
 
     # ensure the properties dictionary is there
     api_data = @api.get_object(@temporary_object_id)
-    api_data["properties"].should_not be_nil
+    expect(api_data["properties"]).not_to be_nil
   end
 
   describe "#put_picture" do
@@ -285,7 +285,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
       result = @api.put_picture(file, content_type)
       @temporary_object_id = result["id"]
-      @temporary_object_id.should_not be_nil
+      expect(@temporary_object_id).not_to be_nil
     end
 
     it "can post photos to the user's wall without an open file object" do
@@ -294,7 +294,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
       result = @api.put_picture(file_path, content_type)
       @temporary_object_id = result["id"]
-      @temporary_object_id.should_not be_nil
+      expect(@temporary_object_id).not_to be_nil
     end
 
     it "can verify a photo posted to a user's wall" do
@@ -305,10 +305,10 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
       result = @api.put_picture(file_path, content_type, :message => expected_message)
       @temporary_object_id = result["id"]
-      @temporary_object_id.should_not be_nil
+      expect(@temporary_object_id).not_to be_nil
 
       get_result = @api.get_object(@temporary_object_id)
-      get_result["name"].should == expected_message
+      expect(get_result["name"]).to eq(expected_message)
     end
 
 
@@ -320,13 +320,13 @@ shared_examples_for "Koala GraphAPI with an access token" do
       it "can post photo to the user's wall using a URL" do
         result = @api.put_picture(@url)
         @temporary_object_id = result["id"]
-        @temporary_object_id.should_not be_nil
+        expect(@temporary_object_id).not_to be_nil
       end
 
       it "can post photo to the user's wall using a URL and an additional param" do
         result = @api.put_picture(@url, :message => "my message")
         @temporary_object_id = result["id"]
-        @temporary_object_id.should_not be_nil
+        expect(@temporary_object_id).not_to be_nil
       end
     end
   end
@@ -339,9 +339,9 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
     it "sets options[:video] to true" do
       source = double("UploadIO")
-      Koala::UploadableIO.stub(:new).and_return(source)
-      source.stub(:requires_base_http_service).and_return(false)
-      Koala.should_receive(:make_request).with(anything, anything, anything, hash_including(:video => true)).and_return(Koala::HTTPService::Response.new(200, "[]", {}))
+      allow(Koala::UploadableIO).to receive(:new).and_return(source)
+      allow(source).to receive(:requires_base_http_service).and_return(false)
+      expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(:video => true)).and_return(Koala::HTTPService::Response.new(200, "[]", {}))
       @api.put_video("foo")
     end
 
@@ -350,13 +350,13 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
       result = @api.put_video(file, @content_type)
       @temporary_object_id = result["id"]
-      @temporary_object_id.should_not be_nil
+      expect(@temporary_object_id).not_to be_nil
     end
 
     it "can post videos to the user's wall without an open file object" do
       result = @api.put_video(@cat_movie, @content_type)
       @temporary_object_id = result["id"]
-      @temporary_object_id.should_not be_nil
+      expect(@temporary_object_id).not_to be_nil
     end
 
     # note: Facebook doesn't post videos immediately to the wall, due to processing time
@@ -372,7 +372,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
     # make sure the result we fetch includes all the parameters we sent
     it_matches = attachment.inject(true) {|valid, param| valid && (get_result[param[0]] == attachment[param[0]])}
-    it_matches.should == true
+    expect(it_matches).to eq(true)
   end
 
   it "can comment on an object" do
@@ -381,7 +381,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
     # this will be deleted when the post gets deleted
     comment_result = @api.put_comment(@temporary_object_id, "it's my comment!")
-    comment_result.should_not be_nil
+    expect(comment_result).not_to be_nil
   end
 
   it "can verify a comment posted about an object" do
@@ -395,38 +395,38 @@ shared_examples_for "Koala GraphAPI with an access token" do
     get_result = @api.get_object(comment_result["id"])
 
     # make sure the text of the comment matches what we sent
-    get_result["message"].should == comment_text
+    expect(get_result["message"]).to eq(comment_text)
   end
 
   it "can like an object" do
     result = @api.put_wall_post("Hello, world, from the test suite, testing liking!")
     @temporary_object_id = result["id"]
     like_result = @api.put_like(@temporary_object_id)
-    like_result.should be_truthy
+    expect(like_result).to be_truthy
   end
 
   # Page Access Token Support
   describe "#get_page_access_token" do
     it "gets the page object with the access_token field" do
       # we can't test this live since test users (or random real users) can't be guaranteed to have pages to manage
-      @api.should_receive(:api).with("my_page", hash_including({:fields => "access_token"}), "get", anything)
+      expect(@api).to receive(:api).with("my_page", hash_including({:fields => "access_token"}), "get", anything)
       @api.get_page_access_token("my_page")
     end
 
     it "merges in any other arguments" do
       # we can't test this live since test users (or random real users) can't be guaranteed to have pages to manage
       args = {:a => 3}
-      @api.should_receive(:api).with("my_page", hash_including(args), "get", anything)
+      expect(@api).to receive(:api).with("my_page", hash_including(args), "get", anything)
       @api.get_page_access_token("my_page", args)
     end
   end
 
   it "can get information about an access token" do
     result = @api.debug_token(KoalaTest.app_access_token)
-    result.should be_kind_of(Hash)
-    result["data"].should be_kind_of(Hash)
-    result["data"]["app_id"].to_s.should == KoalaTest.app_id.to_s
-    result["data"]["application"].should_not be_nil
+    expect(result).to be_kind_of(Hash)
+    expect(result["data"]).to be_kind_of(Hash)
+    expect(result["data"]["app_id"].to_s).to eq(KoalaTest.app_id.to_s)
+    expect(result["data"]["application"]).not_to be_nil
   end
 
   describe "#set_app_restrictions" do
@@ -438,31 +438,31 @@ shared_examples_for "Koala GraphAPI with an access token" do
     end
 
     it "makes a POST to /app_id" do
-      @app_api.should_receive(:graph_call).with(KoalaTest.app_id, anything, "post", anything)
+      expect(@app_api).to receive(:graph_call).with(KoalaTest.app_id, anything, "post", anything)
       @app_api.set_app_restrictions(KoalaTest.app_id, @restrictions)
     end
 
     it "JSON-encodes the restrictions" do
-      @app_api.should_receive(:graph_call).with(anything, hash_including(:restrictions => MultiJson.dump(@restrictions)), anything, anything)
+      expect(@app_api).to receive(:graph_call).with(anything, hash_including(:restrictions => MultiJson.dump(@restrictions)), anything, anything)
       @app_api.set_app_restrictions(KoalaTest.app_id, @restrictions)
     end
 
     it "includes the other arguments" do
       args = {:a => 2}
-      @app_api.should_receive(:graph_call).with(anything, hash_including(args), anything, anything)
+      expect(@app_api).to receive(:graph_call).with(anything, hash_including(args), anything, anything)
       @app_api.set_app_restrictions(KoalaTest.app_id, @restrictions, args)
     end
 
     it "works" do
-      @app_api.set_app_restrictions(KoalaTest.app_id, @restrictions).should be true
+      expect(@app_api.set_app_restrictions(KoalaTest.app_id, @restrictions)).to be true
     end
   end
 
   it "can access public information via FQL" do
     result = @api.fql_query("select uid, first_name from user where uid = #{KoalaTest.user2_id}")
-    result.size.should == 1
-    result.first['first_name'].should == KoalaTest.user2_name
-    result.first['uid'].should == KoalaTest.user2_id.to_i
+    expect(result.size).to eq(1)
+    expect(result.first['first_name']).to eq(KoalaTest.user2_name)
+    expect(result.first['uid']).to eq(KoalaTest.user2_id.to_i)
   end
 
   it "can access public information via FQL.multiquery" do
@@ -470,11 +470,11 @@ shared_examples_for "Koala GraphAPI with an access token" do
       :query1 => "select uid, first_name from user where uid = #{KoalaTest.user2_id}",
       :query2 => "select uid, first_name from user where uid = #{KoalaTest.user1_id}"
     )
-    result.size.should == 2
+    expect(result.size).to eq(2)
     # this should check for first_name, but there's an FB bug currently
-    result["query1"].first['uid'].should == KoalaTest.user2_id.to_i
+    expect(result["query1"].first['uid']).to eq(KoalaTest.user2_id.to_i)
     # result["query1"].first['first_name'].should == KoalaTest.user2_name
-    result["query2"].first['first_name'].should == KoalaTest.user1_name
+    expect(result["query2"].first['first_name']).to eq(KoalaTest.user1_name)
   end
 
   it "can access protected information via FQL" do
@@ -488,9 +488,9 @@ shared_examples_for "Koala GraphAPI with an access token" do
     # now send a query about your permissions
     result = @api.fql_query("select read_stream from permissions where uid = #{id}")
 
-    result.size.should == 1
+    expect(result.size).to eq(1)
     # we've verified that you have read_stream permissions, so we can test against that
-    result.first["read_stream"].should == 1
+    expect(result.first["read_stream"]).to eq(1)
   end
 
   it "can access protected information via FQL.multiquery" do
@@ -499,8 +499,8 @@ shared_examples_for "Koala GraphAPI with an access token" do
       :query2 => "select fromid from comment where post_id in (select post_id from #query1)",
       :query3 => "select uid, name from user where uid in (select fromid from #query2)"
     )
-    result.size.should == 3
-    result.keys.should include("query1", "query2", "query3")
+    expect(result.size).to eq(3)
+    expect(result.keys).to include("query1", "query2", "query3")
   end
 
   # test all methods to make sure they pass data through to the API
@@ -532,7 +532,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
       it "passes http options through for #{method_name}" do
         options = {:a => 2}
         # graph call should ultimately receive options as the fourth argument
-        @api.should_receive(:graph_call).with(anything, anything, anything, options)
+        expect(@api).to receive(:graph_call).with(anything, anything, anything, options)
 
         # if we supply args, use them (since some methods process params)
         # the method should receive as args n-1 anythings and then options
@@ -546,7 +546,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
     it "passes http options through for get_picture" do
       options = {:a => 2}
       # graph call should ultimately receive options as the fourth argument
-      @api.should_receive(:graph_call).with(anything, anything, anything, hash_including(options)).and_return({})
+      expect(@api).to receive(:graph_call).with(anything, anything, anything, hash_including(options)).and_return({})
       @api.send(:get_picture, "x", {}, options)
     end
   end
@@ -559,35 +559,35 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
     # GraphCollection methods
     it "gets a GraphCollection when getting connections" do
       @result = @api.get_connections(KoalaTest.page, "photos")
-      @result.should be_a(Koala::Facebook::GraphCollection)
+      expect(@result).to be_a(Koala::Facebook::GraphCollection)
     end
 
     it "returns nil if the get_collections call fails with nil" do
       # this happens sometimes
-      @api.should_receive(:graph_call).and_return(nil)
-      @api.get_connections(KoalaTest.page, "photos").should be_nil
+      expect(@api).to receive(:graph_call).and_return(nil)
+      expect(@api.get_connections(KoalaTest.page, "photos")).to be_nil
     end
 
     it "gets a GraphCollection when searching" do
       result = @api.search("facebook")
-      result.should be_a(Koala::Facebook::GraphCollection)
+      expect(result).to be_a(Koala::Facebook::GraphCollection)
     end
 
     it "returns nil if the search call fails with nil" do
       # this happens sometimes
-      @api.should_receive(:graph_call).and_return(nil)
-      @api.search("facebook").should be_nil
+      expect(@api).to receive(:graph_call).and_return(nil)
+      expect(@api.search("facebook")).to be_nil
     end
 
     it "gets a GraphCollection when paging through results" do
       @results = @api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}])
-      @results.should be_a(Koala::Facebook::GraphCollection)
+      expect(@results).to be_a(Koala::Facebook::GraphCollection)
     end
 
     it "returns nil if the page call fails with nil" do
       # this happens sometimes
-      @api.should_receive(:graph_call).and_return(nil)
-      @api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}]).should be_nil
+      expect(@api).to receive(:graph_call).and_return(nil)
+      expect(@api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}])).to be_nil
     end
   end
 end
@@ -597,57 +597,57 @@ shared_examples_for "Koala GraphAPI without an access token" do
   it "can't get private data about a user" do
     result = @api.get_object(KoalaTest.user1)
     # updated_time should be a pretty fixed test case
-    result["updated_time"].should be_nil
+    expect(result["updated_time"]).to be_nil
   end
 
   it "can't get data about 'me'" do
-    lambda { @api.get_object("me") }.should raise_error(Koala::Facebook::ClientError)
+    expect { @api.get_object("me") }.to raise_error(Koala::Facebook::ClientError)
   end
 
   it "can't access connections from users" do
-    lambda { @api.get_connections(KoalaTest.user2, "friends") }.should raise_error(Koala::Facebook::ClientError)
+    expect { @api.get_connections(KoalaTest.user2, "friends") }.to raise_error(Koala::Facebook::ClientError)
   end
 
   it "can't put an object" do
-    lambda { @result = @api.put_connections(KoalaTest.user2, "feed", :message => "Hello, world") }.should raise_error(Koala::Facebook::AuthenticationError)
+    expect { @result = @api.put_connections(KoalaTest.user2, "feed", :message => "Hello, world") }.to raise_error(Koala::Facebook::AuthenticationError)
     # legacy put_object syntax
-    lambda { @result = @api.put_object(KoalaTest.user2, "feed", :message => "Hello, world") }.should raise_error(Koala::Facebook::AuthenticationError)
+    expect { @result = @api.put_object(KoalaTest.user2, "feed", :message => "Hello, world") }.to raise_error(Koala::Facebook::AuthenticationError)
   end
 
   # these are not strictly necessary as the other put methods resolve to put_connections,
   # but are here for completeness
   it "can't post to a feed" do
-    (lambda do
+    expect(lambda do
       attachment = {:name => "OAuth Playground", :link => "http://oauth.twoalex.com/"}
       @result = @api.put_wall_post("Hello, world", attachment, "facebook")
-    end).should raise_error(Koala::Facebook::AuthenticationError)
+    end).to raise_error(Koala::Facebook::AuthenticationError)
   end
 
   it "can't comment on an object" do
     # random public post on the facebook wall
-    lambda { @result = @api.put_comment("7204941866_119776748033392", "The hackathon was great!") }.should raise_error(Koala::Facebook::AuthenticationError)
+    expect { @result = @api.put_comment("7204941866_119776748033392", "The hackathon was great!") }.to raise_error(Koala::Facebook::AuthenticationError)
   end
 
   it "can't like an object" do
-    lambda { @api.put_like("7204941866_119776748033392") }.should raise_error(Koala::Facebook::AuthenticationError)
+    expect { @api.put_like("7204941866_119776748033392") }.to raise_error(Koala::Facebook::AuthenticationError)
   end
 
   # DELETE
   it "can't delete posts" do
     # test post on the Ruby SDK Test application
-    lambda { @result = @api.delete_object("115349521819193_113815981982767") }.should raise_error(Koala::Facebook::AuthenticationError)
+    expect { @result = @api.delete_object("115349521819193_113815981982767") }.to raise_error(Koala::Facebook::AuthenticationError)
   end
 
   it "can't delete a like" do
-    lambda { @api.delete_like("7204941866_119776748033392") }.should raise_error(Koala::Facebook::AuthenticationError)
+    expect { @api.delete_like("7204941866_119776748033392") }.to raise_error(Koala::Facebook::AuthenticationError)
   end
 
   # FQL_QUERY
   describe "when making a FQL request" do
     it "can access public information via FQL" do
       result = @api.fql_query("select uid, first_name from user where uid = #{KoalaTest.user2_id}")
-      result.size.should == 1
-      result.first['first_name'].should == KoalaTest.user2_name
+      expect(result.size).to eq(1)
+      expect(result.first['first_name']).to eq(KoalaTest.user2_name)
     end
 
     it "can access public information via FQL.multiquery" do
@@ -655,23 +655,23 @@ shared_examples_for "Koala GraphAPI without an access token" do
         :query1 => "select uid, first_name from user where uid = #{KoalaTest.user2_id}",
         :query2 => "select uid, first_name from user where uid = #{KoalaTest.user1_id}"
       )
-      result.size.should == 2
-      result["query1"].first['first_name'].should == KoalaTest.user2_name
-      result["query2"].first['first_name'].should == KoalaTest.user1_name
+      expect(result.size).to eq(2)
+      expect(result["query1"].first['first_name']).to eq(KoalaTest.user2_name)
+      expect(result["query2"].first['first_name']).to eq(KoalaTest.user1_name)
     end
 
     it "can't access protected information via FQL" do
-      lambda { @api.fql_query("select read_stream from permissions where uid = #{KoalaTest.user2_id}") }.should raise_error(Koala::Facebook::APIError)
+      expect { @api.fql_query("select read_stream from permissions where uid = #{KoalaTest.user2_id}") }.to raise_error(Koala::Facebook::APIError)
     end
 
     it "can't access protected information via FQL.multiquery" do
-      lambda {
+      expect {
         @api.fql_multiquery(
           :query1 => "select post_id from stream where source_id = me()",
           :query2 => "select fromid from comment where post_id in (select post_id from #query1)",
           :query3 => "select uid, name from user where uid in (select fromid from #query2)"
         )
-      }.should raise_error(Koala::Facebook::APIError)
+      }.to raise_error(Koala::Facebook::APIError)
     end
   end
 end

--- a/spec/support/koala_test.rb
+++ b/spec/support/koala_test.rb
@@ -55,7 +55,7 @@ module KoalaTest
     RSpec.configure do |config|
       config.before :each do
         @token = KoalaTest.oauth_token
-        Koala::Utils.stub(:deprecate) # never fire deprecation warnings
+        allow(Koala::Utils).to receive(:deprecate) # never fire deprecation warnings
       end
 
       config.after :each do

--- a/spec/support/rest_api_shared_examples.rb
+++ b/spec/support/rest_api_shared_examples.rb
@@ -3,7 +3,7 @@ shared_examples_for "Koala RestAPI" do
   describe "when making a rest request" do
     it "uses the proper path" do
       method = double('methodName')
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         "method/#{method}",
         anything,
         anything,
@@ -14,7 +14,7 @@ shared_examples_for "Koala RestAPI" do
     end
 
     it "always uses the rest api" do
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         anything,
         anything,
@@ -27,7 +27,7 @@ shared_examples_for "Koala RestAPI" do
     it "sets the read_only option to true if the method is listed in the read-only list" do
       method = Koala::Facebook::RestAPI::READ_ONLY_METHODS.first
 
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         anything,
         anything,
@@ -40,7 +40,7 @@ shared_examples_for "Koala RestAPI" do
     it "sets the read_only option to false if the method is not inthe read-only list" do
       method = "I'm not a read-only method"
 
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         anything,
         anything,
@@ -54,7 +54,7 @@ shared_examples_for "Koala RestAPI" do
     it "takes an optional hash of arguments" do
       args = {:arg1 => 'arg1'}
 
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         hash_including(args),
         anything,
@@ -65,7 +65,7 @@ shared_examples_for "Koala RestAPI" do
     end
 
     it "always asks for JSON" do
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         hash_including('format' => 'json'),
         anything,
@@ -78,7 +78,7 @@ shared_examples_for "Koala RestAPI" do
     it "passes any options provided to the API" do
       options = {:a => 2}
 
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         hash_including('format' => 'json'),
         anything,
@@ -89,7 +89,7 @@ shared_examples_for "Koala RestAPI" do
     end
 
     it "uses get by default" do
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         anything,
         "get",
@@ -101,7 +101,7 @@ shared_examples_for "Koala RestAPI" do
 
     it "allows you to specify other http methods as the last argument" do
       method = 'bar'
-      @api.should_receive(:api).with(
+      expect(@api).to receive(:api).with(
         anything,
         anything,
         method,
@@ -112,8 +112,8 @@ shared_examples_for "Koala RestAPI" do
     end
 
     it "throws an APIError if the status code >= 400" do
-      Koala.stub(:make_request).and_return(Koala::HTTPService::Response.new(500, '{"error_code": "An error occurred!"}', {}))
-      lambda { @api.rest_call(KoalaTest.user1, {}) }.should raise_exception(Koala::Facebook::APIError)
+      allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(500, '{"error_code": "An error occurred!"}', {}))
+      expect { @api.rest_call(KoalaTest.user1, {}) }.to raise_exception(Koala::Facebook::APIError)
     end
   end
 
@@ -126,29 +126,29 @@ shared_examples_for "Koala RestAPI with an access token" do
   describe "#set_app_properties" do
     it "sends Facebook the properties JSON-encoded as :properties" do
       props = {:a => 2, :c => [1, 2, "d"]}
-      @api.should_receive(:rest_call).with(anything, hash_including(:properties => MultiJson.dump(props)), anything, anything)
+      expect(@api).to receive(:rest_call).with(anything, hash_including(:properties => MultiJson.dump(props)), anything, anything)
       @api.set_app_properties(props)
     end
 
     it "calls the admin.setAppProperties method" do
-      @api.should_receive(:rest_call).with("admin.setAppProperties", anything, anything, anything)
+      expect(@api).to receive(:rest_call).with("admin.setAppProperties", anything, anything, anything)
       @api.set_app_properties({})
     end
 
     it "includes any other provided arguments" do
       args = {:c => 3, :d => "a"}
-      @api.should_receive(:rest_call).with(anything, hash_including(args), anything, anything)
+      expect(@api).to receive(:rest_call).with(anything, hash_including(args), anything, anything)
       @api.set_app_properties({:a => 2}, args)
     end
 
     it "includes any http_options provided" do
       opts = {:c => 3, :d => "a"}
-      @api.should_receive(:rest_call).with(anything, anything, opts, anything)
+      expect(@api).to receive(:rest_call).with(anything, anything, opts, anything)
       @api.set_app_properties({}, {}, opts)
     end
 
     it "makes a POST" do
-      @api.should_receive(:rest_call).with(anything, anything, anything, "post")
+      expect(@api).to receive(:rest_call).with(anything, anything, anything, "post")
       @api.set_app_properties({})
     end
 
@@ -156,7 +156,7 @@ shared_examples_for "Koala RestAPI with an access token" do
       oauth = Koala::Facebook::OAuth.new(KoalaTest.app_id, KoalaTest.secret)
       app_token = oauth.get_app_access_token
       @app_api = Koala::Facebook::API.new(app_token)
-      @app_api.set_app_properties(KoalaTest.app_properties).should be true
+      expect(@app_api.set_app_properties(KoalaTest.app_properties)).to be true
     end
   end
 end
@@ -164,6 +164,6 @@ end
 
 shared_examples_for "Koala RestAPI without an access token" do
   it "can't use set_app_properties" do
-    lambda { @api.set_app_properties(:desktop => 0) }.should raise_error(Koala::Facebook::AuthenticationError)
+    expect { @api.set_app_properties(:desktop => 0) }.to raise_error(Koala::Facebook::AuthenticationError)
   end
 end

--- a/spec/support/uploadable_io_shared_examples.rb
+++ b/spec/support/uploadable_io_shared_examples.rb
@@ -8,21 +8,21 @@ shared_examples_for "MIME::Types can't return results" do
     it "should properly get content types for #{extension} using basic analysis" do
       path = "filename.#{extension}"
       if @koala_io_params[0].is_a?(File)
-        @koala_io_params[0].stub(:path).and_return(path)
+        allow(@koala_io_params[0]).to receive(:path).and_return(path)
       else
         @koala_io_params[0] = path
       end
-      Koala::UploadableIO.new(*@koala_io_params).content_type.should == mime_type
+      expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(mime_type)
     end
 
     it "should get content types for #{extension} using basic analysis with file names with more than one dot" do
       path = "file.name.#{extension}"
       if @koala_io_params[0].is_a?(File)
-        @koala_io_params[0].stub(:path).and_return(path)
+        allow(@koala_io_params[0]).to receive(:path).and_return(path)
       else
         @koala_io_params[0] = path
       end
-      Koala::UploadableIO.new(*@koala_io_params).content_type.should == mime_type
+      expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(mime_type)
     end
   end
 
@@ -30,14 +30,14 @@ shared_examples_for "MIME::Types can't return results" do
     before :each do
       path = "badfile.badextension"
       if @koala_io_params[0].is_a?(File)
-        @koala_io_params[0].stub(:path).and_return(path)
+        allow(@koala_io_params[0]).to receive(:path).and_return(path)
       else
         @koala_io_params[0] = path
       end
     end
 
     it "should throw an exception" do
-      lambda { Koala::UploadableIO.new(*@koala_io_params) }.should raise_exception(Koala::KoalaError)
+      expect { Koala::UploadableIO.new(*@koala_io_params) }.to raise_exception(Koala::KoalaError)
     end
   end
 end
@@ -46,15 +46,15 @@ shared_examples_for "determining a mime type" do
   describe "if MIME::Types is available" do
     it "should return an UploadIO with MIME::Types-determined type if the type exists" do
       type_result = ["type"]
-      Koala::MIME::Types.stub(:type_for).and_return(type_result)
-      Koala::UploadableIO.new(*@koala_io_params).content_type.should == type_result.first
+      allow(Koala::MIME::Types).to receive(:type_for).and_return(type_result)
+      expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(type_result.first)
     end
   end
 
   describe "if MIME::Types is unavailable" do
     before :each do
       # fake that MIME::Types doesn't exist
-      Koala::MIME::Types.stub(:type_for).and_raise(NameError)
+      allow(Koala::MIME::Types).to receive(:type_for).and_raise(NameError)
     end
     it_should_behave_like "MIME::Types can't return results"
   end
@@ -62,7 +62,7 @@ shared_examples_for "determining a mime type" do
   describe "if MIME::Types can't find the result" do
     before :each do
       # fake that MIME::Types doesn't exist
-      Koala::MIME::Types.stub(:type_for).and_return([])
+      allow(Koala::MIME::Types).to receive(:type_for).and_return([])
     end
 
     it_should_behave_like "MIME::Types can't return results"


### PR DESCRIPTION
1. Applied transpec to convert to RSpec 3.0.x syntax
2. Updated rspec version in gemspec
3. Fixed a few remaining post-transpec issues.
