### PR TITLE
Fix undefined method 'use_ssl=' error

### DIFF
--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -90,7 +90,7 @@ module Koala
 
       # set up our Faraday connection
       # we have to manually assign params to the URL or the
-      conn = Faraday.new(server(request_options), faraday_options(request_options), &(faraday_middleware || DEFAULT_MIDDLEWARE))
+      conn = Faraday.new(server(request_options), faraday_options(request_options).reject{|k, v| k == :use_ssl}, &(faraday_middleware || DEFAULT_MIDDLEWARE))
 
       response = conn.send(verb, path, (verb == "post" ? params : {}))
 


### PR DESCRIPTION
When I updated gems, NoMethodError occurred.

Error:

```
NoMethodError:
  undefined method `use_ssl=' for #<Faraday::ConnectionOptions:0x007f886a42f5f0>
```

Call stack:

```
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/faraday-0.9.0/lib/faraday/options.rb:31:in `update'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/faraday-0.9.0/lib/faraday/options.rb:53:in `merge'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/faraday-0.9.0/lib/faraday.rb:69:in `new'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/koala-1.6.0/lib/koala/http_service.rb:76:in `make_request'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/koala-1.6.0/lib/koala.rb:51:in `make_request'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/koala-1.6.0/lib/koala/api.rb:51:in `api'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/koala-1.6.0/lib/koala/api/graph_api.rb:468:in `graph_call'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/koala-1.6.0/lib/koala/api/graph_api.rb:58:in `get_object'
/Users/awakia/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/koala-1.6.0/lib/koala/api/graph_api.rb:325:in `fql_query'
```

I examined the error cause, and found out the change below in connection.rb of faraday gem causes this error

```
   def initialize(url = nil, options = nil)
       if url.is_a?(Hash)
-        options = url
-        url     = options[:url]
+        options = ConnectionOptions.from(url)
+        url     = options.url
```

c.f. https://github.com/lostisland/faraday/compare/v0.8.7...v0.9.0

This one line fix can solve this issue, so can you merge this?
If you want to fix this issue the other way, I'm happy to help it :)
