### PR TITLE
the api method should not change the args hash (fixes issue #365)

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -48,6 +48,10 @@ module Koala
       #
       # @return the body of the response from Facebook (unless another http_component is requested)
       def api(path, args = {}, verb = "get", options = {}, &error_checking_block)
+        # we make a copy of args so the modifications (added access_token & appsecret_proof)
+        # do not affect the received argument
+        args = args.dup
+
         # If a access token is explicitly provided, use that
         # This is explicitly needed in batch requests so GraphCollection
         # results preserve any specific access tokens provided

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -30,6 +30,21 @@ describe "Koala::Facebook::API" do
     service.api('anything')
   end
 
+  it "doesn't add token to received arguments" do
+    token = 'adfadf'
+    service = Koala::Facebook::API.new token
+
+    expect(Koala).to receive(:make_request).with(
+                       anything,
+                       hash_including('access_token' => token),
+                       anything,
+                       anything
+                     ).and_return(Koala::HTTPService::Response.new(200, "", ""))
+
+    args = {}.freeze
+    service.api('anything', args)
+  end
+
   it "has an attr_reader for access token" do
     token = 'adfadf'
     service = Koala::Facebook::API.new token

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -20,6 +20,12 @@ describe 'Koala::Facebook::GraphAPIMethods' do
         allow(@api).to receive(:api).and_return(double("other results"))
         expect(@api.get_object('koppel', &post_processing)["result"]).to eq(result)
       end
+
+      it "doesn't add token to received arguments" do
+        args = {}.freeze
+        expect(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, "", ""))
+        expect(@api.get_object('koppel', args, &post_processing)["result"]).to eq(result)
+      end
     end
 
     context '#get_picture' do


### PR DESCRIPTION
It's a quick fix for the issue #365.
