### PR TITLE
Updating readme to properly specify timeout option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -224,7 +224,7 @@ Koala.http_service.http_options = {
   :ssl => { :ca_path => "/etc/ssl/certs" }
 }
 # or on a per-request basis
-@api.get_object(id, args_hash, { :timeout => 10 })
+@api.get_object(id, args_hash, { :request => { :timeout => 10 } })
 ```
 The <a href="https://github.com/arsduo/koala/wiki/HTTP-Services">HTTP Services wiki page</a> has more information on what options are available, as well as on how to configure your own Faraday middleware stack (for instance, to implement request logging).
 


### PR DESCRIPTION
In its current form, the `:timeout` option has no effect.  Examples below run on release https://github.com/arsduo/koala/releases/tag/v1.9.0 and Faraday 0.9.0.

``` ruby
@api = Koala::Facebook::API.new('...')
@api.get_object('me', {}, { :timeout => 0.01 })
 => { ...my profile... } 
```

Instead, it needs to be nested under the `:request` key for Faraday to respect it.

``` ruby
@api = Koala::Facebook::API.new('...')
@api.get_object('me', {}, { :request => { :timeout => 0.01 }})
Faraday::TimeoutError: execution expired
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:763:in `initialize'
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:763:in `open'
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:763:in `block in connect'
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:763:in `connect'
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:756:in `do_start'
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:745:in `start'
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:1285:in `request'
    from /.../.rvm/rubies/ruby-1.9.3-p484/lib/ruby/1.9.1/net/http.rb:1027:in `get'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/faraday-0.9.0/lib/faraday/adapter/net_http.rb:78:in `perform_request'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/faraday-0.9.0/lib/faraday/adapter/net_http.rb:39:in `call'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/faraday-0.9.0/lib/faraday/request/url_encoded.rb:15:in `call'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/faraday-0.9.0/lib/faraday/request/multipart.rb:14:in `call'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/faraday-0.9.0/lib/faraday/rack_builder.rb:139:in `build_response'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/faraday-0.9.0/lib/faraday/connection.rb:377:in `run_request'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/faraday-0.9.0/lib/faraday/connection.rb:140:in `get'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/koala-1.9.0/lib/koala/http_service.rb:95:in `make_request'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/koala-1.9.0/lib/koala.rb:65:in `make_request'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/koala-1.9.0/lib/koala/api.rb:66:in `api'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/koala-1.9.0/lib/koala/api/graph_api.rb:501:in `graph_call'
    from /.../.rvm/gems/ruby-1.9.3-p484@koala/gems/koala-1.9.0/lib/koala/api/graph_api.rb:56:in `get_object'
    from (irb):6
```
