### PR TITLE
Update specs to RSpec 3.0.0.beta2 syntax with Transpec

### DIFF
--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -173,14 +173,14 @@ describe "Koala::Facebook::API" do
           let(:api) { Koala::Facebook::API.new(access_token, appsecret) }
 
           it "will be included by default" do
-            Koala.should_receive(:make_request).with(path, token_args.merge(appsecret_proof_args), verb, {}).and_return(response)
+            expect(Koala).to receive(:make_request).with(path, token_args.merge(appsecret_proof_args), verb, {}).and_return(response)
             api.api(path, {}, verb, :appsecret_proof => true)
           end
         end
 
         describe "but without an appsecret included on API initialization" do
           it "will not be included" do
-            Koala.should_receive(:make_request).with(path, token_args, verb, {}).and_return(response)
+            expect(Koala).to receive(:make_request).with(path, token_args, verb, {}).and_return(response)
             api.api(path, {}, verb, :appsecret_proof => true)
           end
         end
@@ -191,7 +191,7 @@ describe "Koala::Facebook::API" do
           let(:api) { Koala::Facebook::API.new(nil, appsecret) }
 
           it "will not be included" do
-            Koala.should_receive(:make_request).with(path, {}, verb, {}).and_return(response)
+            expect(Koala).to receive(:make_request).with(path, {}, verb, {}).and_return(response)
             api.api(path, {}, verb, :appsecret_proof => true)
           end
         end
@@ -200,7 +200,7 @@ describe "Koala::Facebook::API" do
           let(:api) { Koala::Facebook::API.new }
 
           it "will not be included" do
-            Koala.should_receive(:make_request).with(path, {}, verb, {}).and_return(response)
+            expect(Koala).to receive(:make_request).with(path, {}, verb, {}).and_return(response)
             api.api(path, {}, verb, :appsecret_proof => true)
           end
         end

--- a/spec/cases/test_users_spec.rb
+++ b/spec/cases/test_users_spec.rb
@@ -299,7 +299,7 @@ describe "Koala::Facebook::TestUsers" do
 
       if KoalaTest.mock_interface?
         id_counter = 999999900
-        allow(@test_users).to receive(:create).and_return do
+        allow(@test_users).to receive(:create) do
           id_counter += 1
           {"id" => id_counter, "access_token" => @token, "login_url" => "https://www.facebook.com/platform/test_account.."}
         end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 4 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 1 conversion
  from: allow(obj).to receive(:message).and_return
    to: allow(obj).to receive(:message)
