### PR TITLE
Switch to byebug for MRI Ruby 2.0 and 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
 group :development do
-  gem 'debugger'
+  gem 'debugger', :platforms => [:mri_19]
+  gem 'byebug', :platforms => [:mri_20, :mri_21]
   gem "yard"
 end
 


### PR DESCRIPTION
The latest version of MRI Ruby 2.1 is not supported by debugger.  Switching MRI Ruby 2.0 and 2.1 to use byebug.
