### PR TITLE
Fix syntax error of example

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -119,7 +119,7 @@ module Koala
 
       # Write an object to the Graph for a specific user.
       # See {http://developers.facebook.com/docs/api#publishing Facebook's documentation}
-      # for all the supported writeable objects. It is important to note that objects 
+      # for all the supported writeable objects. It is important to note that objects
       # take the singular form, i.e. "event" when using put_connections.
       #
       # @note (see #get_connection)
@@ -237,7 +237,7 @@ module Koala
       #
       # @example
       #       @api.put_wall_post("Hello there!", {
-      #         "name" => "Link name"
+      #         "name" => "Link name",
       #         "link" => "http://www.example.com/",
       #         "caption" => "{*actor*} posted a new review",
       #         "description" => "This is a longer description of the attachment",


### PR DESCRIPTION
Fix syntax error of example.

before

``` rb
      # @example
      #       @api.put_wall_post("Hello there!", {
      #         "name" => "Link name"
      #         "link" => "http://www.example.com/",
      #         "caption" => "{*actor*} posted a new review",
      #         "description" => "This is a longer description of the attachment",
      #         "picture" => "http://www.example.com/thumbnail.jpg"
      #       })
```

after

``` rb
      # @example
      #       @api.put_wall_post("Hello there!", {
      #         "name" => "Link name",
      #         "link" => "http://www.example.com/",
      #         "caption" => "{*actor*} posted a new review",
      #         "description" => "This is a longer description of the attachment",
      #         "picture" => "http://www.example.com/thumbnail.jpg"
      #       })
```
