### PR TITLE
Fix setting the Facebook API version

### DIFF
--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -47,17 +47,12 @@ module Koala
     # @option options :video use the server designated for video uploads
     # @option options :beta use the beta tier
     # @option options :use_ssl force https, even if not needed
-    # @option options :api_version a version of the Facebook API, e.g. v2.0
     #
     # @return a complete server address with protocol
     def self.server(options = {})
       server = "#{options[:rest_api] ? Koala.config.rest_server : Koala.config.graph_server}"
       server.gsub!(Koala.config.host_path_matcher, Koala.config.video_replace) if options[:video]
       server.gsub!(Koala.config.host_path_matcher, Koala.config.beta_replace) if options[:beta]
-      # ...and an API version if specified
-      if api_version = options[:api_version] || Koala.config.api_version
-        server = "#{server}/#{api_version}"
-      end
       "#{options[:use_ssl] ? "https" : "http"}://#{server}"
     end
 
@@ -91,6 +86,13 @@ module Koala
       if request_options[:use_ssl]
         ssl = (request_options[:ssl] ||= {})
         ssl[:verify] = true unless ssl.has_key?(:verify)
+      end
+
+      # if an api_version is specified, prepend it to the path
+      if api_version = request_options[:api_version] || Koala.config.api_version
+        begins_with_slash = path[0] == "/"
+        divider = begins_with_slash ? "" : "/"
+        path = "/#{api_version}#{divider}#{path}"
       end
 
       # set up our Faraday connection


### PR DESCRIPTION
With these changes, specifying an `api_version` either in the global config or on a per-request basis actually works as advertised in the README. :)

Fixes #390
