### PR TITLE
Adding support for app_secret to be passed on to the Graph API

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -469,7 +469,7 @@ module Koala
       # @return an array of results from your batch calls (as if you'd made them individually),
       #         arranged in the same order they're made.
       def batch(http_options = {}, &block)
-        batch_client = GraphBatchAPI.new(access_token, self)
+        batch_client = GraphBatchAPI.new(access_token, app_secret, self)
         if block
           yield batch_client
           batch_client.execute(http_options)

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -9,8 +9,8 @@ module Koala
       include GraphAPIMethods
 
       attr_reader :original_api
-      def initialize(access_token, api)
-        super(access_token)
+      def initialize(access_token, app_secret, api)
+        super(access_token, app_secret)
         @original_api = api
       end
 


### PR DESCRIPTION
The app_secret is not passed to the GraphBatchAPI by default, so if the security setting for "App Secret Proof for Server API calls" is turned on, then all batch requests will fail. This passes the app_secret of the original api on to the batch api.