### PR TITLE
Add More Detail to Error Messages

### DIFF
--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -14,7 +14,7 @@ module Koala
     # http_status, then the error was detected before making a call to Facebook. (e.g. missing access token)
     class APIError < ::Koala::KoalaError
       attr_accessor :fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message,
-                    :http_status, :response_body
+                    :fb_error_user_message, :fb_error_user_title, :http_status, :response_body
 
       # Create a new API Error
       #
@@ -51,6 +51,8 @@ module Koala
           self.fb_error_code = error_info["code"]
           self.fb_error_subcode = error_info["error_subcode"]
           self.fb_error_message = error_info["message"]
+          self.fb_error_user_message = error_info["error_user_message"]
+          self.fb_error_user_title = error_info["error_user_title"]
 
           error_array = []
           %w(type code error_subcode message).each do |key|

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -5,7 +5,7 @@ describe Koala::Facebook::APIError do
     expect(Koala::Facebook::APIError.new(nil, nil)).to be_a(Koala::KoalaError)
   end
 
-  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :http_status, :response_body].each do |accessor|
+  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :fb_error_user_message, :fb_error_user_title, :http_status, :response_body].each do |accessor|
     it "has an accessor for #{accessor}" do
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(accessor)
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(:"#{accessor}=")
@@ -27,7 +27,9 @@ describe Koala::Facebook::APIError do
         'type' => 'type',
         'message' => 'message',
         'code' => 1,
-        'error_subcode' => 'subcode'
+        'error_subcode' => 'subcode',
+        'error_user_message' => 'error user message',
+        'error_user_title' => 'error user title'
       }
       Koala::Facebook::APIError.new(400, '', error_info)
     }
@@ -36,7 +38,9 @@ describe Koala::Facebook::APIError do
       :fb_error_type => 'type',
       :fb_error_message => 'message',
       :fb_error_code => 1,
-      :fb_error_subcode => 'subcode'
+      :fb_error_subcode => 'subcode',
+      :fb_error_user_message => 'error user message',
+      :fb_error_user_title => 'error user title'
     }.each_pair do |accessor, value|
       it "sets #{accessor} to #{value}" do
         expect(error.send(accessor)).to eq(value)
@@ -58,13 +62,15 @@ describe Koala::Facebook::APIError do
 
   context "with no error_info and a response_body containing error JSON" do
     it "should extract the error info from the response body" do
-      response_body = '{ "error": { "type": "type", "message": "message", "code": 1, "error_subcode": "subcode" } }'
+      response_body = '{ "error": { "type": "type", "message": "message", "code": 1, "error_subcode": "subcode", "error_user_message": "error user message", "error_user_title": "error user title" } }'
       error = Koala::Facebook::APIError.new(400, response_body)
       {
         :fb_error_type => 'type',
         :fb_error_message => 'message',
         :fb_error_code => 1,
-        :fb_error_subcode => 'subcode'
+        :fb_error_subcode => 'subcode',
+        :fb_error_user_message => 'error user message',
+        :fb_error_user_title => 'error user title'
       }.each_pair do |accessor, value|
         expect(error.send(accessor)).to eq(value)
       end


### PR DESCRIPTION
- This adds the new error message fields `error_user_message` and `error_user_title` which contain valuable failure information
- https://developers.facebook.com/docs/graph-api/using-graph-api/v2.1

**Example**

``` json
  {
    "error": {
      "message": "Message describing the error",
        "type": "OAuthException",
        "code": 190,
        "error_subcode": 460,
        "error_user_title": "A title",
        "error_user_msg": "A message"
    }
  }
```
