### PR TITLE
Pass api_version as a request option rather than as a part of path.

### DIFF
--- a/lib/koala/api/graph_collection.rb
+++ b/lib/koala/api/graph_collection.rb
@@ -102,7 +102,9 @@ module Koala
           base = uri.path.sub(/^\//, '')
           params = CGI.parse(uri.query)
 
-          new_params = {}
+          api_version, base = $1, $3 if base =~ /(v\d\.\d)(\/)(.*)/
+
+          new_params = api_version ? {'api_version' => api_version} : {}
           params.each_pair do |key,value|
             new_params[key] = value.join ","
           end

--- a/spec/cases/graph_collection_spec.rb
+++ b/spec/cases/graph_collection_spec.rb
@@ -112,6 +112,16 @@ describe Koala::Facebook::GraphCollection do
         base, args_hash = Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/foo?token=#{access_token}")
         expect(args_hash["token"]).to eq(access_token)
       end
+
+      it 'works with adresses with included API version' do
+        base = 'me/tagged_places'
+        api_version = 'v2.2'
+        args_without_api_hash = {'param' => 'value', 'second_param' => 'value'}
+        get_params = args_without_api_hash.map { |k, v| "#{k}=#{v}" }.join '&'
+        args_hash = { 'api_version' => 'v2.2' }.merge args_without_api_hash
+        path = "https://graph.facebook.com/#{api_version}/#{base}?#{get_params}"
+        expect(Koala::Facebook::GraphCollection.parse_page_url(path)).to eq [base, args_hash]
+      end
     end
   end
 


### PR DESCRIPTION
Hi!

This is fix for issue [#406](https://github.com/arsduo/koala/issues/406).

I know there are two fixes for this issue, but I think they don't always work well. IMHO after parse next page URL we should pass api_version as a request option rather than as a part of base path.
