### PR TITLE
Try to parse  access_token response.body as JSON

### DIFF
--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -316,11 +316,12 @@ module Koala
       end
 
       def parse_access_token(response_text)
-        components = response_text.split("&").inject({}) do |hash, bit|
+        JSON.parse(response_text)
+      rescue JSON::ParserError
+        response_text.split("&").inject({}) do |hash, bit|
           key, value = bit.split("=")
           hash.merge!(key => value)
         end
-        components
       end
 
       def parse_unsigned_cookie(fb_cookie)


### PR DESCRIPTION
It looks like Facebook Graph API is now returning JSON response for the "access_token" end-point. This change updates the `parse_access_token` method to try to parse the response as JSON before doing it's own parsing. 

In the current version (1.10.1), the `OAuth#get_access_token_info` method returns something like:

``` Ruby
{"{\"access_token\":\"CAAFXHuBquhABA0B8N7ATIXe8rMx9hyU6sGl6mEJg6nJeaJRIr6c60StNjaONm9Ks0ZCOSRt1SxS1F7LT4rI0D3wcoEYGD9n37WmQxWBsSsJMYWHjqERoLAodfaMnbkKkBIZAXZBBrZAJJpM5duM3QDZCoZAlVOfglGwgEE2LhrONANmeNQcpez\",\"machine_id\":\"C0RhVJb0EHTWTxloOa4P0Jvp\",\"expires_in\":5170749}"=>nil} 
```
