### PR TITLE
GraphBatchAPI#graph_call_in_batch: allow for string or symbol options.

### DIFF
--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -19,12 +19,15 @@ module Koala
       end
 
       def graph_call_in_batch(path, args = {}, verb = "get", options = {}, &post_processing)
-        # for batch APIs, we queue up the call details (incl. post-processing)
+        # normalize options for consistency
+        options = Koala::Utils.symbolize_hash(options)
+
+        # for batch APIs, we queue up the call details (incl. post-processing)        
         batch_calls << BatchOperation.new(
           :url => path,
           :args => args,
           :method => verb,
-          :access_token => options['access_token'] || access_token,
+          :access_token => options[:access_token] || access_token,
           :http_options => options,
           :post_processing => post_processing
         )

--- a/lib/koala/utils.rb
+++ b/lib/koala/utils.rb
@@ -29,5 +29,13 @@ module Koala
         @posted_deprecations << message
       end
     end
+
+    # Ensures that a hash uses symbols as opposed to strings
+    # Useful for allowing either syntax for end users
+    def symbolize_hash(hash)
+      return hash unless hash.is_a?(Hash)
+
+      hash.inject({}){ |memo,(key,value)| memo[key.to_sym] = symbolize_hash(value); memo }
+    end
   end
 end

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -519,6 +519,15 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
       expect(insights).to be_an(Koala::Facebook::GraphCollection)
     end
 
+    it "handles requests passing the access token option as a symbol instead of a string" do
+      me, insights = @api.batch do |batch_api|
+        batch_api.get_object('me')
+        batch_api.get_connections(@app_id, 'insights', {}, {:access_token => @app_api.access_token})
+      end
+      expect(me['id']).not_to be_nil
+      expect(insights).to be_an(Koala::Facebook::GraphCollection)
+    end
+
     it "preserves batch-op specific access tokens in GraphCollection returned from batch" do
       # Provide an alternate token for a batch operation
       @other_access_token_args = { 'access_token' => @app_api.access_token }


### PR DESCRIPTION
Introduces a simple symbolize_hash method in Koala::Utils to accomplish this.

This is nothing more than a convenience that allows users not to have to think about how they pass in an options hash.

Fixes #409 
