### PR TITLE
GraphBatchAPI reads access_token and app_secret from API instance.

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -469,7 +469,7 @@ module Koala
       # @return an array of results from your batch calls (as if you'd made them individually),
       #         arranged in the same order they're made.
       def batch(http_options = {}, &block)
-        batch_client = GraphBatchAPI.new(access_token, self)
+        batch_client = GraphBatchAPI.new(self)
         if block
           yield batch_client
           batch_client.execute(http_options)

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -9,8 +9,8 @@ module Koala
       include GraphAPIMethods
 
       attr_reader :original_api
-      def initialize(access_token, api)
-        super(access_token)
+      def initialize(api)
+        super(api.access_token, api.app_secret)
         @original_api = api
       end
 

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -297,6 +297,19 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           end
         end
 
+        context 'with appsecret_proof and app_secret' do
+          it "includes the app_secret in the API call" do
+            access_token = "foo"
+            app_secret = "baz"
+            app_secret_digest = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), app_secret, access_token)
+            expect(Koala).to receive(:make_request).with(anything, hash_including("access_token" => access_token, "appsecret_proof" => app_secret_digest), anything, anything).and_return(@fake_response)
+            Koala::Facebook::API.new(access_token, app_secret).batch do |batch_api|
+              batch_api.get_object('me')
+              batch_api.get_object('me', {}, {'access_token' => 'bar'})
+            end
+          end
+        end
+
         it "sets args['batch'] to a json'd map of all the batch params" do
           access_token = "bar"
           op = Koala::Facebook::GraphBatchAPI::BatchOperation.new(:access_token => access_token, :method => :get, :url => "/")


### PR DESCRIPTION
This enables batch API methods to use the API object's appsecret_proof in the request. See #407 