### PR TITLE
Fix error message attribute name

### DIFF
--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -14,7 +14,7 @@ module Koala
     # http_status, then the error was detected before making a call to Facebook. (e.g. missing access token)
     class APIError < ::Koala::KoalaError
       attr_accessor :fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message,
-                    :fb_error_user_message, :fb_error_user_title, :http_status, :response_body
+                    :fb_error_user_msg, :fb_error_user_title, :http_status, :response_body
 
       # Create a new API Error
       #
@@ -51,11 +51,11 @@ module Koala
           self.fb_error_code = error_info["code"]
           self.fb_error_subcode = error_info["error_subcode"]
           self.fb_error_message = error_info["message"]
-          self.fb_error_user_message = error_info["error_user_message"]
+          self.fb_error_user_msg = error_info["error_user_msg"]
           self.fb_error_user_title = error_info["error_user_title"]
 
           error_array = []
-          %w(type code error_subcode message error_user_title error_user_message).each do |key|
+          %w(type code error_subcode message error_user_title error_user_msg).each do |key|
             error_array << "#{key}: #{error_info[key]}" if error_info[key]
           end
 

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -5,7 +5,7 @@ describe Koala::Facebook::APIError do
     expect(Koala::Facebook::APIError.new(nil, nil)).to be_a(Koala::KoalaError)
   end
 
-  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :fb_error_user_message, :fb_error_user_title, :http_status, :response_body].each do |accessor|
+  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :fb_error_user_msg, :fb_error_user_title, :http_status, :response_body].each do |accessor|
     it "has an accessor for #{accessor}" do
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(accessor)
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(:"#{accessor}=")
@@ -28,7 +28,7 @@ describe Koala::Facebook::APIError do
         'message' => 'message',
         'code' => 1,
         'error_subcode' => 'subcode',
-        'error_user_message' => 'error user message',
+        'error_user_msg' => 'error user message',
         'error_user_title' => 'error user title'
       }
       Koala::Facebook::APIError.new(400, '', error_info)
@@ -39,7 +39,7 @@ describe Koala::Facebook::APIError do
       :fb_error_message => 'message',
       :fb_error_code => 1,
       :fb_error_subcode => 'subcode',
-      :fb_error_user_message => 'error user message',
+      :fb_error_user_msg => 'error user message',
       :fb_error_user_title => 'error user title'
     }.each_pair do |accessor, value|
       it "sets #{accessor} to #{value}" do
@@ -48,7 +48,7 @@ describe Koala::Facebook::APIError do
     end
 
     it "sets the error message appropriately" do
-      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_message: error user message [HTTP 400]")
+      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_msg: error user message [HTTP 400]")
     end
   end
 
@@ -62,14 +62,14 @@ describe Koala::Facebook::APIError do
 
   context "with no error_info and a response_body containing error JSON" do
     it "should extract the error info from the response body" do
-      response_body = '{ "error": { "type": "type", "message": "message", "code": 1, "error_subcode": "subcode", "error_user_message": "error user message", "error_user_title": "error user title" } }'
+      response_body = '{ "error": { "type": "type", "message": "message", "code": 1, "error_subcode": "subcode", "error_user_msg": "error user message", "error_user_title": "error user title" } }'
       error = Koala::Facebook::APIError.new(400, response_body)
       {
         :fb_error_type => 'type',
         :fb_error_message => 'message',
         :fb_error_code => 1,
         :fb_error_subcode => 'subcode',
-        :fb_error_user_message => 'error user message',
+        :fb_error_user_msg => 'error user message',
         :fb_error_user_title => 'error user title'
       }.each_pair do |accessor, value|
         expect(error.send(accessor)).to eq(value)


### PR DESCRIPTION
d80e63189fc6506fa21147ee8d288cebcabec103 did use the wrong attribute name for the error user message as seen by example such as [this](http://stackoverflow.com/questions/26017216/create-a-link-ad-for-a-facebook-object-event-url) or [this](https://www.facebook.com/help/community/question/?id=10100513795846507). It should be `error_user_msg` instead of `error_user_message`.