### PR TITLE
Allow Array type as a parameter

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -60,9 +60,6 @@ module Koala
           args["appsecret_proof"] = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), @app_secret, args["access_token"])
         end
 
-        # Translate any arrays in the params into comma-separated strings
-        args = sanitize_request_parameters(args)
-
         # add a leading / if needed...
         path = "/#{path}" unless path =~ /^\//
 
@@ -83,26 +80,6 @@ module Koala
           # Note: Facebook sometimes sends results like "true" and "false", which aren't strictly objects
           # and cause MultiJson.load to fail -- so we account for that by wrapping the result in []
           MultiJson.load("[#{result.body.to_s}]")[0]
-        end
-      end
-
-      private
-
-      # Sanitizes Ruby objects into Facebook-compatible string values.
-      #
-      # @param parameters a hash of parameters.
-      #
-      # Returns a hash in which values that are arrays of non-enumerable values
-      #         (Strings, Symbols, Numbers, etc.) are turned into comma-separated strings.
-      def sanitize_request_parameters(parameters)
-        parameters.reduce({}) do |result, (key, value)|
-          # if the parameter is an array that contains non-enumerable values,
-          # turn it into a comma-separated list
-          # in Ruby 1.8.7, strings are enumerable, but we don't care
-          if value.is_a?(Array) && value.none? {|entry| entry.is_a?(Enumerable) && !entry.is_a?(String)}
-            value = value.join(",")
-          end
-          result.merge(key => value)
         end
       end
     end

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -75,26 +75,6 @@ describe "Koala::Facebook::API" do
     expect(@service.api('anything', {}, 'get', :http_component => http_component)).to eq(response)
   end
 
-  it "turns arrays of non-enumerables into comma-separated arguments" do
-    args = [12345, {:foo => [1, 2, "3", :four]}]
-    expected = ["/12345", {:foo => "1,2,3,four"}, "get", {}]
-    response = double('Mock KoalaResponse', :body => '', :status => 200)
-    expect(Koala).to receive(:make_request).with(*expected).and_return(response)
-    @service.api(*args)
-  end
-
-  it "doesn't turn arrays containing enumerables into comma-separated strings" do
-    params = {:foo => [1, 2, ["3"], :four]}
-    args = [12345, params]
-    # we leave this as is -- the HTTP layer can either handle it appropriately
-    # (if appropriate behavior is defined)
-    # or raise an exception
-    expected = ["/12345", params, "get", {}]
-    response = double('Mock KoalaResponse', :body => '', :status => 200)
-    expect(Koala).to receive(:make_request).with(*expected).and_return(response)
-    @service.api(*args)
-  end
-
   it "returns the body of the request as JSON if no http_component is given" do
     response = double('response', :body => 'body', :status => 200)
     allow(Koala).to receive(:make_request).and_return(response)


### PR DESCRIPTION
Hi @arsduo

I'd like to propose reverting e6d27af, which made it possible to pass in basic request parameters as an array. It looks like you expressed a little hesitation in the corresponding [pull request](https://github.com/arsduo/koala/pull/289), but ultimately couldn't think of a use case where it would cause an issue. From working with the Facebook Ads Api, there are parameters that require an array of string values ([FB Ad Group](https://developers.facebook.com/docs/reference/ads-api/adgroup/v2.2): see `social_prefs` and `view_tags` for Create as an example). Since the existing implementation always joins an array of string elements, I'm getting a Facebook exception specifying that "param social_prefs must be an array" for the following request.

```ruby
@graph.put_connections('act_12345', 'adgroups', {
  name: 'foo',
  adgroup_status: 'foo',
  objective: 'WEBSITE_CLICKS',
  campaign_id: 12345,
  creative: {'creative_id': 12345},
  social_prefs: ['ALLOW_SHARES']
})
```

While passing parameters as an array may be convenient, I think the existing implementation is overly strict. I realize this may be a breaking change for many, so I also want to be sensitive to the current contract. Do you have any suggestions on how to accommodate the existing API along with allowing an array of string values? Perhaps, joining the values for specific keys (such as `fields` shown below)?
> GET graph.facebook.com/bgolub?fields=id,name,picture