### PR TITLE
Added possibility to return picture data.

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -183,6 +183,17 @@ module Koala
         block ? block.call(resolved_result) : resolved_result
       end
 
+      # Fetches a photo data.
+      #
+      # @param args (see #get_object)
+      # @param options (see Koala::Facebook::API#api)
+      # @param block (see Koala::Facebook::API#api)
+      #
+      # @return a hash of object data
+      def get_user_picture_data(object, args = {}, options = {}, &block)
+        graph_call("#{object}/picture", args.merge(:redirect => false), "get", options, &block)
+      end
+
       # Upload a photo.
       #
       # This can be called in multiple ways:

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -241,6 +241,10 @@ graph_api:
           headers:
             Location: https://facebook.com/large
 
+    redirect=false:
+      get:
+        no_token: '{"is_silhouette": true, "url": "https://facebook.com/large"}'
+        with_token: '{"is_silhouette": true, "url": "https://facebook.com/large"}'
   /comments:
     ids=http://developers.facebook.com/blog/post/472:
       get:

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -103,6 +103,11 @@ shared_examples_for "Koala GraphAPI" do
     end
   end
 
+  it "can access a user's picture data" do
+    result = @api.get_user_picture_data(KoalaTest.user2)
+    expect(result.key?("is_silhouette")).to be_truthy
+  end
+
   it "can access connections from public Pages" do
     result = @api.get_connections(KoalaTest.page, "photos")
     expect(result).to be_a(Array)


### PR DESCRIPTION
As described in #424 it wasn't possible to return picture json.
When looking at the gem API it might not be intuitive to get this result by passing `redirect: false`, but when looking at FB API, this is what you would expect https://developers.facebook.com/docs/graph-api/reference/v2.2/user/picture

If you think that this method is doing to much, I can extract it to separate method, but I'm not sure what would be the best name for it.