### PR TITLE
Speed up builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: ruby
+sudo: false
+cache: bundler
 rvm:
   # MRI
   - 1.9.3


### PR DESCRIPTION
`sudo: false` enables docker containers: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
`cache: bundler` caches bundled gems between builds