### PR TITLE
Allow custom post processing for batch get_picture

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -177,10 +177,10 @@ module Koala
       # @return the URL to the image
       def get_picture(object, args = {}, options = {}, &block)
         # Gets a picture object, returning the URL (which Facebook sends as a header)
-        resolved_result = graph_call("#{object}/picture", args, "get", options.merge(:http_component => :headers)) do |result|
-          result ? result["Location"] : nil
+        graph_call("#{object}/picture", args, "get", options.merge(:http_component => :headers)) do |result|
+          resolved_result = result ? result["Location"] : nil
+          block ? block.call(resolved_result) : resolved_result
         end
-        block ? block.call(resolved_result) : resolved_result
       end
 
       # Upload a photo.

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -510,6 +510,14 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
       expect(pictures.first).to match(/http\:\/\//) # works both live & stubbed
     end
 
+    it 'takes an after processing block for a get_picture call inside of a batch' do
+      picture = nil
+      @api.batch do |batch_api|
+        batch_api.get_picture('me') { |pic| picture = pic }
+      end
+      expect(picture).to match(/http\:\/\//) # works both live & stubbed
+    end
+
     it "handles requests for two different tokens" do
       me, insights = @api.batch do |batch_api|
         batch_api.get_object('me')


### PR DESCRIPTION
* Allow custom post_processing blocks to be used with `get_picture` inside of a batch request