### PR TITLE
Allow per-request specification of :api_version

### DIFF
--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -90,7 +90,7 @@ module Koala
 
       # if an api_version is specified and the path does not already contain
       # one, prepend it to the path
-      api_version = request_options[:api_version] || Koala.config.api_version
+      api_version = args[:api_version] || Koala.config.api_version
       if api_version && !path_contains_api_version?(path)
         begins_with_slash = path[0] == "/"
         divider = begins_with_slash ? "" : "/"

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -281,7 +281,7 @@ describe Koala::HTTPService do
       it "uses an api_version specified in the request params" do
         expect(Koala.config).not_to receive(:api_version)
         expect(@mock_connection).to receive(:get).with("/v11/anything", anything)
-        Koala::HTTPService.make_request("anything", { api_version: "v11"}, "get")
+        Koala::HTTPService.make_request("anything", { api_version: "v11" }, "get")
       end
 
       it "falls back to a version specified via Koala.config" do

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -278,23 +278,21 @@ describe Koala::HTTPService do
 
 
     context "with API versions" do
-      it "adds a version if specified by Koala.config" do
+      it "uses an api_version specified in the request params" do
+        expect(Koala.config).not_to receive(:api_version)
+        expect(@mock_connection).to receive(:get).with("/v11/anything", anything)
+        Koala::HTTPService.make_request("anything", { api_version: "v11"}, "get")
+      end
+
+      it "falls back to a version specified via Koala.config" do
         expect(Koala.config).to receive(:api_version).and_return("v11")
         expect(@mock_connection).to receive(:get).with("/v11/anything", anything)
         Koala::HTTPService.make_request("anything", {}, "get")
       end
 
-      it "prefers a version set in http_options" do
-        allow(Koala.config).to receive(:api_version).and_return("v11")
-        allow(Koala::HTTPService).to receive(:http_options).and_return({ api_version: 'v12' })
-        expect(@mock_connection).to receive(:get).with("/v12/anything", anything)
-        Koala::HTTPService.make_request("anything", {}, "get")
-      end
-
       it "doesn't add double slashes to the path" do
-        allow(Koala::HTTPService).to receive(:http_options).and_return({ api_version: 'v12' })
         expect(@mock_connection).to receive(:get).with("/v12/anything", anything)
-        Koala::HTTPService.make_request("/anything", {}, "get")
+        Koala::HTTPService.make_request("/anything", { api_version: "v12" }, "get")
       end
 
       it "doesn't add a version if the path already contains one" do


### PR DESCRIPTION
Encountered a bug in `Koala::HTTPService.make_request` where it wasn't grabbing the `:api_version` symbol from the correct hash:

1) Line 81 stringifies `:api_version` to `"api_version"`.
2) Line 84 nests the `"api_version"` key-value pair one level deep inside the `request_options` hash.
3) Line 93 had no way of pulling `:api_version` from `request_options`.

Two obvious ways of fixing it:
1) On line 93, look for `request_options[:params]["api_version"]`
2) On line 93, look for `args[:api_version]`

I opted for the latter because it seemed likely that the `api_version` was misplaced inside the `request_options[:params]` hash in the first place. Also, it's less code. The tests I've written/modified verify that the feature is now working as documented in the README.

Let me know how it looks and/or if there's anything else I can do.

Thanks!