### PR TITLE
Return message when graph API returns 304

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -500,7 +500,14 @@ module Koala
         options = {:appsecret_proof => true}.merge(options) if @app_secret
         result = api(path, args, verb, options) do |response|
           error = check_response(response.status, response.body)
-          raise error if error
+          if error
+            raise error
+          elsif response.status.to_i == 304
+            return {
+              "message" => "Etags sent with request match response",
+              "response_code" => "304",
+            }
+          end
         end
 
         # turn this into a GraphCollection if it's pageable

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -26,6 +26,15 @@ describe 'Koala::Facebook::GraphAPIMethods' do
         expect(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, "", ""))
         expect(@api.get_object('koppel', args, &post_processing)["result"]).to eq(result)
       end
+
+      context "etag headers sent with response match data" do
+        it "returns a 304 and helpful response body" do
+          response_hash = { "message" => "Etags sent with request match response", "response_code" => "304" }
+          expect(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(304, "", ""))
+
+          expect(@api.get_object("koppel", {})).to eq(response_hash)
+        end
+      end
     end
 
     context '#get_picture' do


### PR DESCRIPTION
* If sending etags to graph API and etags match, response body will be nil
* Source: https://developers.facebook.com/docs/marketing-api/etags