### PR TITLE
[Etags] Return Koala::HTTPService::Response.new 

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -77,7 +77,13 @@ module Koala
 
         # if we want a component other than the body (e.g. redirect header for images), return that
         if component = options[:http_component]
-          component == :response ? result : result.send(options[:http_component])
+          if component == :response
+            parsed_body = MultiJson.load("[#{result.body.to_s}]")[0]
+            result.body = parsed_body
+            result
+          else
+            result.send(options[:http_component])
+          end
         else
           # parse the body as JSON and run it through the error checker (if provided)
           # Note: Facebook sometimes sends results like "true" and "false", which aren't strictly objects

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -504,7 +504,11 @@ module Koala
         end
 
         # turn this into a GraphCollection if it's pageable
-        result = GraphCollection.evaluate(result, self)
+        if options[:http_component] && options[:http_component] == :response
+          result.body = GraphCollection.evaluate(result.body, self)
+        else
+          result = GraphCollection.evaluate(result, self)
+        end
 
         # now process as appropriate for the given call (get picture header, etc.)
         post_processing ? post_processing.call(result) : result

--- a/lib/koala/api/graph_collection.rb
+++ b/lib/koala/api/graph_collection.rb
@@ -36,7 +36,15 @@ module Koala
         # The Ads API (uniquely so far) returns a hash rather than an array when queried
         # with get_connections.
         def self.evaluate(response, api)
-          response.is_a?(Hash) && response["data"].is_a?(Array) ? self.new(response, api) : response
+          if self.is_graph_collection?(response)
+            return self.new(response, api)
+          else
+            response
+          end
+        end
+
+        def self.is_graph_collection?(response)
+          response.is_a?(Hash) && response["data"].is_a?(Array)
         end
 
         # Retrieve the next page of results.

--- a/lib/koala/http_service/response.rb
+++ b/lib/koala/http_service/response.rb
@@ -2,6 +2,7 @@ module Koala
   module HTTPService
     class Response
       attr_reader :status, :body, :headers
+      attr_writer :body
 
       # Creates a new Response object, which standardizes the response received by Facebook for use within Koala.
       def initialize(status, body, headers)

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,27 @@ You can also make multiple calls at once using Facebook's batch API:
 end
 ```
 
+You can pass headers to Graph API calls via the `options` hash. For example, if
+you want to optimize graph api data fetching with <a
+href="https://developers.facebook.com/blog/post/627/">ETags</a>, you can make a
+graph call with the `etag` from the last request like this:
+
+```ruby
+etag_from_last_request = "\"123abc\""
+
+@graph.get_object(
+  "me",
+  headers: { "If-None-Match" => etag_from_last_request },
+  http_component: :response,
+)
+```
+
+If the ETag passed in the headers matches the current ETag, Koala will not
+return data for the endpoint. Instead, it will return a
+`Koala::HTTPService::Response` with no body and a status of 304. If there is a
+cache miss, the status will be 200 and the body will contain the updated
+Facebook data.
+
 You can pass a "post-processing" block to each of Koala's Graph API methods. This is handy for two reasons:
 
 1. You can modify the result returned by the Graph API method:

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -70,7 +70,7 @@ describe "Koala::Facebook::API" do
 
   it "returns the entire response if http_component => :response" do
     http_component = :response
-    response = double('Mock KoalaResponse', :body => '', :status => 200)
+    response = Koala::HTTPService::Response.new(200, {}, {})
     allow(Koala).to receive(:make_request).and_return(response)
     expect(@service.api('anything', {}, 'get', :http_component => http_component)).to eq(response)
   end

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -86,5 +86,21 @@ describe 'Koala::Facebook::GraphAPIMethods' do
         @api.graph_call(path)
       end
     end
+
+    describe "the http_component option" do
+      it "sends the http_component option to the API call" do
+        path = "/path"
+        api = Koala::Facebook::API.new(@token, "mysecret")
+        response = Koala::HTTPService::Response.new(200, "", "")
+        expect(api).to receive(:api).with(
+          path,
+          {},
+          'get',
+          { appsecret_proof: true, http_component: :response },
+        ).and_return(response)
+
+        api.graph_call(path, {}, 'get', http_component: :response)
+      end
+    end
   end
 end


### PR DESCRIPTION
- when `http_component: :response` option set
- Can use that option to return response with status, body, headers
- Set body to either parsed JSON or GraphCollection object
- Need to know response status to determine if an etag header passed in matches (304)
- Reference: https://developers.facebook.com/docs/marketing-api/etags
- Fixes arsduo#337
