### PR TITLE
Get picture urls from API response instead of HTTP Location header

### DIFF
--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -240,11 +240,11 @@ graph_api:
           code: 302
           headers:
             Location: https://facebook.com/large
-
     redirect=false:
       get:
-        no_token: '{"is_silhouette": true, "url": "https://facebook.com/large"}'
-        with_token: '{"is_silhouette": true, "url": "https://facebook.com/large"}'
+        no_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com" } }'
+        with_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com" } }'
+
   /comments:
     ids=http://developers.facebook.com/blog/post/472:
       get:

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -79,7 +79,7 @@ graph_api:
         with_token: '[{"code": 200, "body":"{\"id\":\"123\"}"}, {"code": 200, "body":"{\"id\":\"456\"}"}]'
     batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/picture"}]) %>:
       post:
-        with_token: '[{"code": 200, "headers":[{"name":"Location","value":"http://google.com"}]}]'
+        with_token: '[{"code": 302, "headers":[{"name":"Location","value":"http://google.com"}]}]'
     batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "me/friends"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"id\":\"koppel\"}"}, {"code": 200, "body":"{\"data\":[{\"id\":\"lukeshepard\"}],\"paging\":{}}"}]'

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -80,6 +80,9 @@ graph_api:
     batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/picture"}]) %>:
       post:
         with_token: '[{"code": 302, "headers":[{"name":"Location","value":"http://google.com"}]}]'
+    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/picture?redirect=false"}]) %>:
+      post:
+        with_token: '[{"code": 200, "body":"{\"data\":{\"is_silhouette\":false,\"url\":\"http:\/\/google.com\"}}"}]'
     batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "me/friends"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"id\":\"koppel\"}"}, {"code": 200, "body":"{\"data\":[{\"id\":\"lukeshepard\"}],\"paging\":{}}"}]'
@@ -167,6 +170,11 @@ graph_api:
       post:
         with_token: '{"id": "FEED_ITEM_DICTIONARY"}'
 
+  /me/picture:
+    redirect=false:
+      no_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com" } }'
+      with_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com" } }'
+
   /me/photos:
     source=[FILE]:
       post:
@@ -244,6 +252,10 @@ graph_api:
       get:
         no_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com" } }'
         with_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com" } }'
+    redirect=false&type=large:
+      get:
+        no_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com/large" } }'
+        with_token: '{ "data": { "is_silhouette": true, "url": "https://facebook.com/large" } }'
 
   /comments:
     ids=http://developers.facebook.com/blog/post/472:

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -99,7 +99,10 @@ shared_examples_for "Koala GraphAPI" do
 
   it "can access a user's picture data" do
     result = @api.get_user_picture_data(KoalaTest.user2)
-    expect(result.key?("is_silhouette")).to be_truthy
+    expect(result).to be_kind_of(Hash)
+    expect(result["data"]).to be_kind_of(Hash)
+    expect(result['data']).to be_truthy
+    expect(result['data'].keys).to include('is_silhouette', 'url')
   end
 
   it "can access connections from public Pages" do


### PR DESCRIPTION
The default behaviour for `graph.facebook.com/me/picture` and other `/picture` endpoints is to return a 302 redirect to the profile photo url. To make these `.../picture` endpoints return responses similar to the rest of the Graph API, we must add the `redirect=false` parameter [0].

Previously, in `API#get_picture` we would make the request to the graph API without this parameter, and then extract the photo URL from the 'Location' header in the HTTP response. This is a little unconventional, and may be responsible for issue #308, although I haven't tested the failure mode
in a batch query here. Instead, we can explicitly request the full API response (via `API#get_user_picture_data`), and then parse out the URL field.

I also cleaned up some of the tests and mocks to make the test suite for this particular weirdness closer to reality.

[0] The current version of the Graph API documentation doesn't seem to note this particular wart; I've opened a bug against their documentation:
https://developers.facebook.com/bugs/383635598495430/

In the meantime, you can find an old version describing this behavior thanks to the Wayback Machine:
http://web.archive.org/web/20131020151411/https://developers.facebook.com/docs/reference/api/using-pictures/