### PR TITLE
Expose passing of array as parameter via config and per-request option

### DIFF
--- a/lib/koala.rb
+++ b/lib/koala.rb
@@ -22,6 +22,8 @@ module Koala
   # See http://github.com/arsduo/koala/wiki for a general introduction to Koala
   # and the Graph API.
 
+  OPTIONS = HTTPService::DEFAULT_SERVERS.merge(join_array_params: true)
+
   # Making HTTP requests
   class << self
     # Control which HTTP service framework Koala uses.
@@ -43,7 +45,7 @@ module Koala
     #   * api_version: controls which Facebook API version to use (v1.0, v2.0,
     #   etc)
     def config
-      @config ||= OpenStruct.new(HTTPService::DEFAULT_SERVERS)
+      @config ||= OpenStruct.new(OPTIONS)
     end
 
     # Used for testing.

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -61,7 +61,7 @@ module Koala
         end
 
         # Translate any arrays in the params into comma-separated strings
-        args = sanitize_request_parameters(args)
+        args = sanitize_request_parameters(args) if options.fetch :join_array_params, Koala.config.join_array_params
 
         # add a leading / if needed...
         path = "/#{path}" unless path =~ /^\//

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -75,9 +75,29 @@ describe "Koala::Facebook::API" do
     expect(@service.api('anything', {}, 'get', :http_component => http_component)).to eq(response)
   end
 
-  it "turns arrays of non-enumerables into comma-separated arguments" do
+  it "turns arrays of non-enumerables into comma-separated arguments by default" do
     args = [12345, {:foo => [1, 2, "3", :four]}]
     expected = ["/12345", {:foo => "1,2,3,four"}, "get", {}]
+    response = double('Mock KoalaResponse', :body => '', :status => 200)
+    expect(Koala).to receive(:make_request).with(*expected).and_return(response)
+    @service.api(*args)
+  end
+
+  it "can be configured to leave arrays of non-enumerables as is" do
+    Koala.configure do |config|
+      config.join_array_params = false
+    end
+
+    args = [12345, {:foo => [1, 2, "3", :four]}]
+    expected = ["/12345", {:foo => [1, 2, "3", :four]}, "get", {}]
+    response = double('Mock KoalaResponse', :body => '', :status => 200)
+    expect(Koala).to receive(:make_request).with(*expected).and_return(response)
+    @service.api(*args)
+  end
+
+  it "can be configured on a per-request basis to leave arrays as is" do
+    args = [12345, {foo: [1, 2, "3", :four]}, "get", { join_array_params: false }]
+    expected = ["/12345", {foo: [1, 2, "3", :four]}, "get", { join_array_params: false }]
     response = double('Mock KoalaResponse', :body => '', :status => 200)
     expect(Koala).to receive(:make_request).with(*expected).and_return(response)
     @service.api(*args)

--- a/spec/cases/koala_spec.rb
+++ b/spec/cases/koala_spec.rb
@@ -39,7 +39,7 @@ describe Koala do
 
   describe ".config" do
     it "exposes the basic configuration" do
-      Koala::HTTPService::DEFAULT_SERVERS.each_pair do |k, v|
+      Koala::OPTIONS.each_pair do |k, v|
         expect(Koala.config.send(k)).to eq(v)
       end
     end


### PR DESCRIPTION
Per your comment in #431, this PR only introduces the ability to pass arrays as is to Facebook. This functionality is exposed via the config object as well as is overridable on a per-request basis.