### PR TITLE
Allow #put_video by url

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -557,7 +557,8 @@ module Koala
 
         if url?(media_args.first)
           # If media_args is a URL, we can upload without UploadableIO
-          args.merge!(:url => media_args.first)
+          url_arg_name = method == "photos" ? :url : :file_url
+          args.merge!(url_arg_name => media_args.first)
         else
           args["source"] = Koala::UploadableIO.new(*media_args.slice(0, 1 + args_offset))
         end

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -194,6 +194,14 @@ graph_api:
       post:
         <<: *token_required
         with_token: '{"id": "MOCK_PHOTO"}'
+    file_url=http://techslides.com/demos/sample-videos/small.mp4:
+      post:
+        <<: *token_required
+        with_token: '{"id": "MOCK_PHOTO_FROM_URL"}'
+    description=my message&file_url=http://techslides.com/demos/sample-videos/small.mp4:
+      post:
+        <<: *token_required
+        with_token: '{"id": "MOCK_PHOTO_FROM_URL"}'
 
   /koppel:
     no_args:

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -358,6 +358,25 @@ shared_examples_for "Koala GraphAPI with an access token" do
     # note: Facebook doesn't post videos immediately to the wall, due to processing time
     # during which get_object(video_id) will return false
     # hence we can't do the same verify test we do for photos
+
+
+    describe "using a URL instead of a file" do
+      before :each do
+        @url = "http://techslides.com/demos/sample-videos/small.mp4"
+      end
+
+      it "can post photo to the user's wall using a URL" do
+        result = @api.put_video(@url)
+        @temporary_object_id = result["id"]
+        expect(@temporary_object_id).not_to be_nil
+      end
+
+      it "can post photo to the user's wall using a URL and an additional param" do
+        result = @api.put_video(@url, :description => "my message")
+        @temporary_object_id = result["id"]
+        expect(@temporary_object_id).not_to be_nil
+      end
+    end
   end
 
   it "can verify a message with an attachment posted to a feed" do


### PR DESCRIPTION
This was added on API version 2.3.

Check https://developers.facebook.com/docs/graph-api/video-uploads for
"Provide a URL for a downloadable video via the file_url parameter. Available as of v2.3."