### PR TITLE
MultiJson::ParseError renamed as LoadError for backward compatibility

### DIFF
--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -261,7 +261,7 @@ module Koala
 
       def parse_access_token(response_text)
         MultiJson.load(response_text)
-      rescue MultiJson::ParseError
+      rescue MultiJson::LoadError
         response_text.split("&").inject({}) do |hash, bit|
           key, value = bit.split("=")
           hash.merge!(key => value)


### PR DESCRIPTION
fixes issue #449

from multi_json gem doc:
>When loading invalid JSON, MultiJson will throw a MultiJson::ParseError. MultiJson::DecodeError and MultiJson::LoadError are aliases for backwards compatibility.

for backward compatibility use MultiJson::LoadError instead of MultiJson::ParseError