### PR TITLE
Support application/json payloads with Faraday

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -61,7 +61,7 @@ module Koala
         end
 
         # Translate any arrays in the params into comma-separated strings
-        args = sanitize_request_parameters(args)
+        args = sanitize_request_parameters(args) if options[:format] && options[:format].to_s.downcase != "json"
 
         # add a leading / if needed...
         path = "/#{path}" unless path =~ /^\//

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -61,7 +61,7 @@ module Koala
         end
 
         # Translate any arrays in the params into comma-separated strings
-        args = sanitize_request_parameters(args) if options[:format] && options[:format].to_s.downcase != "json"
+        args = sanitize_request_parameters(args) if !options[:format] || (options[:format] && options[:format].to_s.downcase != "json")
 
         # add a leading / if needed...
         path = "/#{path}" unless path =~ /^\//

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -103,6 +103,7 @@ module Koala
 
       if options[:format] && options[:format].to_s.downcase == "json" && verb == "post"
         response = conn.post do |req|
+          req.path = path
           req.headers['Content-Type'] = 'application/json'
           req.body = params.to_json
         end

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -99,9 +99,14 @@ module Koala
 
       # set up our Faraday connection
       # we have to manually assign params to the URL or the
-      conn = Faraday.new(server(request_options), faraday_options(request_options), &(faraday_middleware || DEFAULT_MIDDLEWARE))
-
-      response = conn.send(verb, path, (verb == "post" ? params : {}))
+      if options[:format] && options[:format].to_s.downcase == "json" && verb == "post"
+        response = conn.post do |req|
+          req.headers['Content-Type'] = 'application/json'
+          req.body = params.to_json
+        end
+      else
+        response = conn.send(verb, path, (verb == "post" ? params : {}))
+      end
 
       # Log URL information
       Koala::Utils.debug "#{verb.upcase}: #{path} params: #{params.inspect}"

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -100,7 +100,6 @@ module Koala
       # set up our Faraday connection
       # we have to manually assign params to the URL or the
       conn = Faraday.new(server(request_options), faraday_options(request_options), &(faraday_middleware || DEFAULT_MIDDLEWARE))
-
       if options[:format] && options[:format].to_s.downcase == "json" && verb == "post"
         response = conn.post do |req|
           req.path = path

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -99,6 +99,8 @@ module Koala
 
       # set up our Faraday connection
       # we have to manually assign params to the URL or the
+      conn = Faraday.new(server(request_options), faraday_options(request_options), &(faraday_middleware || DEFAULT_MIDDLEWARE))
+
       if options[:format] && options[:format].to_s.downcase == "json" && verb == "post"
         response = conn.post do |req|
           req.headers['Content-Type'] = 'application/json'

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -95,6 +95,14 @@ describe "Koala::Facebook::API" do
     @service.api(*args)
   end
 
+  it "doesn't modify any data if the option format of JSON is provided" do
+    args = [12345, {:foo => [1, 2, "3", :four]}, 'get', {format: :json}]
+    expected = ["/12345", {:foo => [1, 2, "3", :four]}, 'get', {format: :json}]
+    response = double('Mock KoalaResponse', :body => '', :status => 200)
+    expect(Koala).to receive(:make_request).with(*expected).and_return(response)
+    @service.api(*args)
+  end
+
   it "returns the body of the request as JSON if no http_component is given" do
     response = double('response', :body => 'body', :status => 200)
     allow(Koala).to receive(:make_request).and_return(response)

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -252,6 +252,29 @@ describe Koala::HTTPService do
         Koala::HTTPService.make_request("anything", {"access_token" => "foo"}, "get", options)
       end
 
+      it "calls server with a json object when provided a format option for post requests" do
+        mock_request = double("Faraday::Request")
+
+        allow(mock_request).to receive("path=")
+        allow(mock_request).to receive("body=")
+        content = {}
+        allow(mock_request).to receive("headers").and_return(content)
+
+        mock_connection = double("Faraday connection")
+        allow(mock_connection).to receive(:post).and_yield(mock_request).and_return(@mock_http_response)
+        allow(Faraday).to receive(:new).and_return(mock_connection)
+
+        options = {:a => 2, :c => "3"}
+
+        expect(mock_connection).to receive(:post)
+        expect(mock_request).to receive("path=").with("anything")
+        expect(mock_request).to receive("body=").with(options.to_json)
+
+        Koala::HTTPService.make_request("anything", options, "post", {format: :json})
+
+        expect(mock_request.headers["Content-Type"]).to eq("application/json")
+      end
+
       it "calls server with the composite options" do
         options = {:a => 2, :c => "3"}
         http_options = {:a => :a}


### PR DESCRIPTION
The gem should support being able to send requests to FB as application/json, which the API supports.

I used another (cancelled) pull request but added the necessary tests.