### PR TITLE
Added summary to GraphCollection

### DIFF
--- a/lib/koala/api/graph_collection.rb
+++ b/lib/koala/api/graph_collection.rb
@@ -10,6 +10,8 @@ module Koala
 
         # The raw paging information from Facebook (next/previous URLs).
         attr_reader :paging
+        # The raw summary information from Facebook (total counts).
+        attr_reader :summary
         # @return [Koala::Facebook::GraphAPI] the api used to make requests.
         attr_reader :api
         # The entire raw response from Facebook.
@@ -22,10 +24,11 @@ module Koala
         #            (usually the API that made the original call).
         #
         # @return [Koala::Facebook::GraphCollection] an initialized GraphCollection
-        #         whose paging, raw_response, and api attributes are populated.
+        #         whose paging, summary, raw_response, and api attributes are populated.
         def initialize(response, api)
           super response["data"]
           @paging = response["paging"]
+          @summary = response["summary"]
           @raw_response = response
           @api = api
         end

--- a/spec/cases/graph_collection_spec.rb
+++ b/spec/cases/graph_collection_spec.rb
@@ -6,7 +6,8 @@ describe Koala::Facebook::GraphCollection do
   before(:each) do
     @result = {
       "data" => [1, 2, :three],
-      "paging" => paging
+      "paging" => paging,
+      "summary" => [3]
     }
     @api = Koala::Facebook::API.new("123")
     @collection = Koala::Facebook::GraphCollection.new(@result, @api)
@@ -31,6 +32,10 @@ describe Koala::Facebook::GraphCollection do
 
   it "sets paging to results['paging']" do
     expect(@collection.paging).to eq(@result["paging"])
+  end
+
+  it "sets summary to results['summary']" do
+    expect(@collection.summary).to eq(@result["summary"])
   end
 
   it "sets raw_response to the original results" do


### PR DESCRIPTION
Breaks out summary variable for GraphCollections when provided by Facebook.

Fixes issue #475 