### PR TITLE
Restore search method, which remains supported by Facebook

### DIFF
--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -312,6 +312,20 @@ module Koala
         graph_call("#{id}/likes", {}, "delete", options, &block)
       end
 
+      # Search for a given query among visible Facebook objects.
+      # See {http://developers.facebook.com/docs/reference/api/#searching Facebook documentation} for more information.
+      #
+      # @param search_terms the query to search for
+      # @param args additional arguments, such as type, fields, etc.
+      # @param options (see #get_object)
+      # @param block (see Koala::Facebook::API#api)
+      #
+      # @return [Koala::Facebook::API::GraphCollection] an array of search results
+      def search(search_terms, args = {}, options = {}, &block)
+        args.merge!({:q => search_terms}) unless search_terms.nil?
+        graph_call("search", args, "get", options, &block)
+      end
+
       # Convenience Methods
       # In general, we're trying to avoid adding convenience methods to Koala
       # except to support cases where the Facebook API requires non-standard input

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Koala.config.api_version = "v2.0"
 
 The response of most requests is the JSON data returned from the Facebook servers as a Hash.
 
-When retrieving data that returns an array of results (for example, when calling `API#get_connections`)
+When retrieving data that returns an array of results (for example, when calling `API#get_connections` or `API#search`)
 a GraphCollection object will be returned, which makes it easy to page through the results:
 
 ```ruby

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -271,6 +271,16 @@ graph_api:
         code: 500
         body: '{"error": {"type": "Exception","message": "No node specified"}}'
 
+  /search:
+    q=facebook:
+      get:
+        with_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
+        no_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
+    "limit=25&q=facebook&until=<%= TEST_DATA['search_time'] %>":
+      get:
+        with_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
+        no_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
+
   /fql:
     q=select uid, first_name from user where uid = 2901279:
       get:

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -51,6 +51,12 @@ shared_examples_for "Koala GraphAPI" do
     end
   end
 
+  # SEARCH
+  it "can search" do
+    result = @api.search("facebook")
+    expect(result.length).to be_an(Integer)
+  end
+
   # DATA
   # access public info
 
@@ -115,6 +121,12 @@ shared_examples_for "Koala GraphAPI" do
   it "can access comments for 2 URLs" do
     result = @api.get_comments_for_urls(["http://developers.facebook.com/blog/post/490", "http://developers.facebook.com/blog/post/472"])
     expect(result["http://developers.facebook.com/blog/post/490"] && result["http://developers.facebook.com/blog/post/472"]).to be_truthy
+  end
+
+  # SEARCH
+  it "can search" do
+    result = @api.search("facebook")
+    expect(result.length).to be_an(Integer)
   end
 
   # PAGING THROUGH COLLECTIONS
@@ -534,6 +546,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
       :put_wall_post => 4,
       :put_comment => 3,
       :put_like => 2, :delete_like => 2,
+      :search => 3,
       :set_app_restrictions => 4,
       :get_page_access_token => 3,
       :fql_query => 3, :fql_multiquery => 3,
@@ -582,10 +595,26 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
       expect(@api.get_connections(KoalaTest.page, "photos")).to be_nil
     end
 
+    it "gets a GraphCollection when searching" do
+      result = @api.search("facebook")
+      expect(result).to be_a(Koala::Facebook::GraphCollection)
+    end
+
+    it "returns nil if the search call fails with nil" do
+      # this happens sometimes
+      expect(@api).to receive(:graph_call).and_return(nil)
+      expect(@api.search("facebook")).to be_nil
+    end
+
+    it "gets a GraphCollection when paging through results" do
+      @results = @api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}])
+      expect(@results).to be_a(Koala::Facebook::GraphCollection)
+    end
+
     it "returns nil if the page call fails with nil" do
       # this happens sometimes
       expect(@api).to receive(:graph_call).and_return(nil)
-      expect(@api.get_connections(KoalaTest.page, "photos")).to be_nil
+      expect(@api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}])).to be_nil
     end
   end
 end

--- a/spec/support/koala_test.rb
+++ b/spec/support/koala_test.rb
@@ -3,7 +3,7 @@ module KoalaTest
 
   class << self
     attr_accessor :oauth_token, :app_id, :secret, :app_access_token, :code, :session_key
-    attr_accessor :oauth_test_data, :subscription_test_data
+    attr_accessor :oauth_test_data, :subscription_test_data, :search_time
     attr_accessor :test_user_api
     attr_accessor :vcr_oauth_token
   end
@@ -107,6 +107,9 @@ module KoalaTest
     self.session_key = data["oauth_test_data"]["session_key"]
 
     self.vcr_oauth_token = data["vcr_data"]["oauth_token"]
+
+    # fix the search time so it can be used in the mock responses
+    self.search_time = data["search_time"] || (Time.now - 3600).to_s
   end
 
   def self.testing_permissions


### PR DESCRIPTION
This reverts commit 01db4a9089a59b00c224e083f057b825e75584fd.

Facebook deprecated its Public Posts search API, which led to the removal of this method. However, the search endpoint remains active for some other kinds of searches, like Pages and Ad Targeting. As such, the commit removing the search method is reverted.

In response to issue #400.