### PR TITLE
feature: add values of fb-trace-id, fb-debug and fb-rev to exceptions

### DIFF
--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -22,7 +22,7 @@ module Koala
         # normalize options for consistency
         options = Koala::Utils.symbolize_hash(options)
 
-        # for batch APIs, we queue up the call details (incl. post-processing)        
+        # for batch APIs, we queue up the call details (incl. post-processing)
         batch_calls << BatchOperation.new(
           :url => path,
           :args => args,
@@ -65,7 +65,13 @@ module Koala
 
             raw_result = nil
             if call_result
-              if ( error = check_response(call_result['code'], call_result['body'].to_s) )
+              parsed_headers = if call_result.has_key?('headers')
+                call_result['headers'].inject({}) { |headers, h| headers[h['name']] = h['value']; headers}
+              else
+                {}
+              end
+
+              if ( error = check_response(call_result['code'], call_result['body'].to_s, parsed_headers) )
                 raw_result = error
               else
                 # (see note in regular api method about JSON parsing)
@@ -77,7 +83,7 @@ module Koala
                   call_result["code"].to_i
                 when :headers
                   # facebook returns the headers as an array of k/v pairs, but we want a regular hash
-                  call_result['headers'].inject({}) { |headers, h| headers[h['name']] = h['value']; headers}
+                  parsed_headers
                 else
                   body
                 end

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -14,7 +14,7 @@ module Koala
     # http_status, then the error was detected before making a call to Facebook. (e.g. missing access token)
     class APIError < ::Koala::KoalaError
       attr_accessor :fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message,
-                    :fb_error_user_msg, :fb_error_user_title, :http_status, :response_body
+                    :fb_error_user_msg, :fb_error_user_title, :fb_error_trace_id, :fb_error_debug, :fb_error_rev, :http_status, :response_body
 
       # Create a new API Error
       #
@@ -54,8 +54,12 @@ module Koala
           self.fb_error_user_msg = error_info["error_user_msg"]
           self.fb_error_user_title = error_info["error_user_title"]
 
+          self.fb_error_trace_id = error_info["x-fb-trace-id"]
+          self.fb_error_debug = error_info["x-fb-debug"]
+          self.fb_error_rev = error_info["x-fb-rev"]
+
           error_array = []
-          %w(type code error_subcode message error_user_title error_user_msg).each do |key|
+          %w(type code error_subcode message error_user_title error_user_msg x-fb-trace-id).each do |key|
             error_array << "#{key}: #{error_info[key]}" if error_info[key]
           end
 

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -5,7 +5,7 @@ describe Koala::Facebook::APIError do
     expect(Koala::Facebook::APIError.new(nil, nil)).to be_a(Koala::KoalaError)
   end
 
-  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :fb_error_user_msg, :fb_error_user_title, :http_status, :response_body].each do |accessor|
+  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :fb_error_user_msg, :fb_error_user_title, :fb_error_trace_id, :fb_error_rev, :fb_error_debug, :http_status, :response_body].each do |accessor|
     it "has an accessor for #{accessor}" do
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(accessor)
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(:"#{accessor}=")
@@ -29,7 +29,10 @@ describe Koala::Facebook::APIError do
         'code' => 1,
         'error_subcode' => 'subcode',
         'error_user_msg' => 'error user message',
-        'error_user_title' => 'error user title'
+        'error_user_title' => 'error user title',
+        'x-fb-trace-id' => 'fb trace id',
+        'x-fb-debug' => 'fb debug token',
+        'x-fb-rev' => 'fb revision'
       }
       Koala::Facebook::APIError.new(400, '', error_info)
     }
@@ -40,7 +43,10 @@ describe Koala::Facebook::APIError do
       :fb_error_code => 1,
       :fb_error_subcode => 'subcode',
       :fb_error_user_msg => 'error user message',
-      :fb_error_user_title => 'error user title'
+      :fb_error_user_title => 'error user title',
+      :fb_error_trace_id => 'fb trace id',
+      :fb_error_debug => 'fb debug token',
+      :fb_error_rev => 'fb revision'
     }.each_pair do |accessor, value|
       it "sets #{accessor} to #{value}" do
         expect(error.send(accessor)).to eq(value)
@@ -48,7 +54,7 @@ describe Koala::Facebook::APIError do
     end
 
     it "sets the error message appropriately" do
-      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_msg: error user message [HTTP 400]")
+      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_msg: error user message, x-fb-trace-id: fb trace id [HTTP 400]")
     end
   end
 


### PR DESCRIPTION
Hello!

This PR adds the following Facebook debug headers to Koala exceptions:
* `fb-trace-id`
* `fb-debug`
* `fb-rev`

This information is oftentimes required when reporting bugs to Facebook, and should make it easier to submit issues to their support.

For the record, this probably addresses issue https://github.com/arsduo/koala/issues/477