### PR TITLE
Upgrade RSpec and fix spec problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  # rbx
-  - rbx-2.4.1
+  # Rubinius is failing due to segfaults on Travis (and takes significantly longer to run)
+  # those builds will be restored later
   # jruby
   - jruby-19mode
 bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "rspec", '~> 3.0.0.beta1'
+  gem "rspec", '~> 3.4'
   gem "vcr"
   gem "webmock"
   gem "codeclimate-test-reporter", require: nil

--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -197,7 +197,7 @@ module Koala
       # @return the application access token
       def get_app_access_token(options = {})
         if info = get_app_access_token_info(options)
-          string = info["access_token"]
+          info["access_token"]
         end
       end
 

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -585,18 +585,18 @@ describe "Koala::Facebook::OAuth" do
       # so we only need to test at a high level that it works
       it "throws an error if the algorithm is unsupported" do
         allow(MultiJson).to receive(:load).and_return("algorithm" => "my fun algorithm")
-        expect { @oauth.parse_signed_request(@signed_request) }.to raise_error
+        expect { @oauth.parse_signed_request(@signed_params) }.to raise_error(Koala::Facebook::OAuthSignatureError)
       end
 
       it "throws an error if the signature is invalid" do
         allow(OpenSSL::HMAC).to receive(:hexdigest).and_return("i'm an invalid signature")
-        expect { @oauth.parse_signed_request(@signed_request) }.to raise_error
+        expect { @oauth.parse_signed_request(@signed_params) }.to raise_error(Koala::Facebook::OAuthSignatureError)
       end
 
       it "throws an error if the signature string is empty" do
         # this occasionally happens due to Facebook error
-        expect { @oauth.parse_signed_request("") }.to raise_error
-        expect { @oauth.parse_signed_request("abc-def") }.to raise_error
+        expect { @oauth.parse_signed_request("") }.to raise_error(Koala::Facebook::OAuthSignatureError)
+        expect { @oauth.parse_signed_request("abc-def") }.to raise_error(Koala::Facebook::OAuthSignatureError)
       end
 
       it "properly parses requests" do

--- a/spec/cases/realtime_updates_spec.rb
+++ b/spec/cases/realtime_updates_spec.rb
@@ -106,18 +106,6 @@ describe "Koala::Facebook::RealtimeUpdates" do
       @updates.subscribe("user", "name", @subscription_path, @verify_token)
     end
 
-    pending "doesn't require a verify_token" do
-      # see https://github.com/arsduo/koala/issues/150
-      obj = "user"
-      fields = "name"
-      expect(@updates.api).not_to receive(:graph_call).with(anything, hash_including(:verify_token => anything), anything, anything)
-      @updates.subscribe("user", "name", @subscription_path)
-    end
-
-    it "requires verify_token" do
-      expect { @updates.subscribe("user", "name", @subscription_path) }.to raise_exception
-    end
-
     it "accepts an options hash" do
       options = {:a => 2, :b => "c"}
       expect(@updates.api).to receive(:graph_call).with(anything, anything, anything, hash_including(options))
@@ -127,10 +115,6 @@ describe "Koala::Facebook::RealtimeUpdates" do
     describe "in practice" do
       it "sends a subscription request" do
         expect { @updates.subscribe("user", "name", @subscription_path, @verify_token) }.to_not raise_error
-      end
-
-      pending "sends a subscription request without a verify token" do
-        expect { @updates.subscribe("user", "name", @subscription_path) }.to_not raise_error
       end
 
       it "fails if you try to hit an invalid path on your valid server" do

--- a/spec/cases/test_users_spec.rb
+++ b/spec/cases/test_users_spec.rb
@@ -261,10 +261,6 @@ describe "Koala::Facebook::TestUsers" do
         expect(result).to be_truthy
       end
 
-      it "does not accept user IDs anymore" do
-        expect { @test_users.befriend(@user1["id"], @user2["id"]) }.to raise_exception
-      end
-
       it "accepts http options passed to both calls" do
         options = {:some_http_option => true}
         # should come twice, once for each user

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,13 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 KoalaTest.setup_test_environment!
 
 BEACH_BALL_PATH = File.join(File.dirname(__FILE__), "fixtures", "beach.jpg")
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    # This option should be set when all dependencies are being loaded
+    # before a spec run, as is the case in a typical spec helper. It will
+    # cause any verifying double instantiation for a class that does not
+    # exist to raise, protecting against incorrectly spelt names.
+    mocks.verify_doubled_constant_names = true
+  end
+end


### PR DESCRIPTION
This PR upgrades RSpec from 3.0beta to 3.4 and fixes various warnings it raises. It also eliminates some pended specs that are no longer relevant (RealtimeUpdates requires a verify_token, which at one point was in doubt).