### PR TITLE
Create API#get_picture_data and deprecate old picture methods

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+v2.3.0
+======
+
+Updated features:
+* API#get_user_picture_data is now API#get_picture_data. The old method and API#get_picture both
+  remain with deprecation warnings. (Thanks noahsilas for earlier work on this!)
+
+Testing improvements:
+
+* Upgraded RSpec to 3.3.0
+* Removed pended specs that were no longer relevant
+
 v2.2.0
 ======
 

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -177,6 +177,8 @@ module Koala
       #
       # @return the URL to the image
       def get_picture(object, args = {}, options = {}, &block)
+        Koala::Utils.deprecate("API#get_picture will be removed in a future version. Please use API#get_picture_data, which returns a hash including the url.")
+
         get_user_picture_data(object, args, options) do |result|
           # Try to extract the URL
           result = result.fetch('data', {})['url'] if result.respond_to?(:fetch)
@@ -191,13 +193,18 @@ module Koala
       # @param block (see Koala::Facebook::API#api)
       #
       # @return a hash of object data
-      def get_user_picture_data(object, args = {}, options = {}, &block)
+      def get_picture_data(object, args = {}, options = {}, &block)
         # The default response for a Graph API query like GET /me/picture is to
         # return a 302 redirect. This is a surprising difference from the
         # common return type, so we add the `redirect: false` parameter to get
         # a RESTful API response instead.
         args = args.merge(:redirect => false)
         graph_call("#{object}/picture", args, "get", options, &block)
+      end
+
+      def get_user_picture_data(*args, &block)
+        Koala::Utils.deprecate("API#get_user_picture_data is deprecated and will be removed in a future version. Please use API#get_picture_data, which has the same signature.")
+        get_picture_data(*args, &block)
       end
 
       # Upload a photo.

--- a/lib/koala/version.rb
+++ b/lib/koala/version.rb
@@ -1,3 +1,3 @@
 module Koala
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -30,7 +30,7 @@ describe 'Koala::Facebook::GraphAPIMethods' do
 
     context '#get_picture' do
       it 'returns result of block' do
-        allow(@api).to receive(:api).and_return("Location" => double("other result"))
+        allow(@api).to receive(:api).and_return({"data" => {"is_silhouette" => false, "url" => result}})
         expect(@api.get_picture('lukeshepard', &post_processing)["result"]).to eq(result)
       end
     end

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -103,12 +103,24 @@ shared_examples_for "Koala GraphAPI" do
     end
   end
 
-  it "can access a user's picture data" do
-    result = @api.get_user_picture_data(KoalaTest.user2)
-    expect(result).to be_kind_of(Hash)
-    expect(result["data"]).to be_kind_of(Hash)
-    expect(result['data']).to be_truthy
-    expect(result['data'].keys).to include('is_silhouette', 'url')
+  describe "#get_picture_data" do
+    it "can access a user's picture data" do
+      result = @api.get_picture_data(KoalaTest.user2)
+      expect(result).to be_kind_of(Hash)
+      expect(result["data"]).to be_kind_of(Hash)
+      expect(result['data']).to be_truthy
+      expect(result['data'].keys).to include('is_silhouette', 'url')
+    end
+  end
+
+  describe "#get_user_picture_data" do
+    it "can access a user's picture data" do
+      result = @api.get_picture_data(KoalaTest.user2)
+      expect(result).to be_kind_of(Hash)
+      expect(result["data"]).to be_kind_of(Hash)
+      expect(result['data']).to be_truthy
+      expect(result['data'].keys).to include('is_silhouette', 'url')
+    end
   end
 
   it "can access connections from public Pages" do


### PR DESCRIPTION
In #456, @noahsilas pointed out that API#get_picture really isn't needed anymore and that API#get_user_picture_data is misnamed. This pull request deprecates both those methods in favor of API#get_picture_data (which is otherwise the same as get_user_picture_data). Those methods will be removed in Koala 3.0.