### PR TITLE
Refactor Graph API error handling to include debug headers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,19 @@ v2.3.0
 ======
 
 Updated features:
+
 * API#get_user_picture_data is now API#get_picture_data. The old method and API#get_picture both
   remain with deprecation warnings. (Thanks noahsilas for earlier work on this!)
+
+Internal Improvements:
+
+* Graph API error handling is now done via the GraphErrorChecker class
 
 Testing improvements:
 
 * Upgraded RSpec to 3.3.0
 * Removed pended specs that were no longer relevant
+* Improved https regex in test suite (thanks, lucaskds!)
 
 v2.2.0
 ======

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -524,7 +524,7 @@ module Koala
         # enable appsecret_proof by default
         options = {:appsecret_proof => true}.merge(options) if @app_secret
         result = api(path, args, verb, options) do |response|
-          error = check_response(response.status, response.body)
+          error = check_response(response.status, response.body, response.headers)
           raise error if error
         end
 
@@ -537,7 +537,7 @@ module Koala
 
       private
 
-      def check_response(http_status, response_body)
+      def check_response(http_status, response_body, response_headers = {})
         # Check for Graph API-specific errors. This returns an error of the appropriate type
         # which is immediately raised (non-batch) or added to the list of batch results (batch)
         http_status = http_status.to_i
@@ -558,6 +558,10 @@ module Koala
             }
           else
             error_info = response_hash['error'] || {}
+          end
+
+          %w(x-fb-debug x-fb-rev x-fb-trace-id).each do |debug_header|
+            error_info[debug_header] = response_headers[debug_header] if response_headers.has_key?(debug_header)
           end
 
           if error_info['type'] == 'OAuthException' &&

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -22,7 +22,7 @@ module Koala
         # normalize options for consistency
         options = Koala::Utils.symbolize_hash(options)
 
-        # for batch APIs, we queue up the call details (incl. post-processing)        
+        # for batch APIs, we queue up the call details (incl. post-processing)
         batch_calls << BatchOperation.new(
           :url => path,
           :args => args,
@@ -65,7 +65,13 @@ module Koala
 
             raw_result = nil
             if call_result
-              if ( error = check_response(call_result['code'], call_result['body'].to_s) )
+              parsed_headers = if call_result.has_key?('headers')
+                call_result['headers'].inject({}) { |headers, h| headers[h['name']] = h['value']; headers}
+              else
+                {}
+              end
+
+              if ( error = check_response(call_result['code'], call_result['body'].to_s, parsed_headers) )
                 raw_result = error
               else
                 # (see note in regular api method about JSON parsing)
@@ -77,7 +83,7 @@ module Koala
                   call_result["code"].to_i
                 when :headers
                   # facebook returns the headers as an array of k/v pairs, but we want a regular hash
-                  call_result['headers'].inject({}) { |headers, h| headers[h['name']] = h['value']; headers}
+                  parsed_headers
                 else
                   body
                 end

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -71,7 +71,7 @@ module Koala
                 {}
               end
 
-              if ( error = check_response(call_result['code'], call_result['body'].to_s, parsed_headers) )
+              if (error = check_response(call_result['code'], call_result['body'].to_s, parsed_headers))
                 raw_result = error
               else
                 # (see note in regular api method about JSON parsing)

--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -1,0 +1,71 @@
+module Koala
+  module Facebook
+    # This class, given a Koala::HTTPService::Response object, will check for Graph API-specific
+    # errors. This returns an error of the appropriate type which can be immediately raised
+    # (non-batch) or added to the list of batch results (batch)
+    class GraphErrorChecker
+      attr_reader :http_status, :body, :headers
+      def initialize(http_status, body, headers)
+        @http_status = http_status.to_i
+        @body = body
+        @headers = headers
+      end
+
+      # Facebook has a set of standardized error codes, some of which represent problems with the
+      # token.
+      AUTHENTICATION_ERROR_CODES = [102, 190, 450, 452, 2500]
+
+      # Facebook can return debug information in the response headers -- see
+      # https://developers.facebook.com/docs/graph-api/using-graph-api#bugdebug
+      DEBUG_HEADERS = ["x-fb-debug", "x-fb-rev", "x-fb-trace-id"]
+
+      def error_if_appropriate
+        if http_status >= 400
+          error_class.new(http_status, body, error_info)
+        end
+      end
+
+      protected
+
+      def error_class
+        if auth_error?
+          # See: https://developers.facebook.com/docs/authentication/access-token-expiration/
+          #      https://developers.facebook.com/bugs/319643234746794?browse=search_4fa075c0bd9117b20604672
+          AuthenticationError
+        else
+          ClientError
+        end
+      end
+
+      def auth_error?
+        # tbh, I'm not sure why we restrict Facebook-reported OAuthExceptions to only those without
+        # codes or whose codes match the list above -- let's investigate changing this later.
+        error_info['type'] == 'OAuthException' &&
+          (!error_info['code'] || AUTHENTICATION_ERROR_CODES.include?(error_info['code'].to_i))
+      end
+
+      def error_info
+        # Build up the complete error info from whatever Facebook gives us plus the header
+        # information
+        @error_info ||= DEBUG_HEADERS.inject(base_error_info) do |hash, error_key|
+          hash[error_key] = headers[error_key] if headers[error_key]
+          hash
+        end
+      end
+
+      def base_error_info
+        response_hash['error'] || {}
+      end
+
+      def response_hash
+        # Normally, we start with the response body. If it isn't valid JSON, we start with an empty
+        # hash and fill it with error data.
+        @response_hash ||= begin
+          MultiJson.load(body)
+        rescue MultiJson::DecodeError
+          {}
+        end
+      end
+    end
+  end
+end

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -14,7 +14,7 @@ module Koala
     # http_status, then the error was detected before making a call to Facebook. (e.g. missing access token)
     class APIError < ::Koala::KoalaError
       attr_accessor :fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message,
-                    :fb_error_user_msg, :fb_error_user_title, :http_status, :response_body
+                    :fb_error_user_msg, :fb_error_user_title, :fb_error_trace_id, :fb_error_debug, :fb_error_rev, :http_status, :response_body
 
       # Create a new API Error
       #
@@ -54,8 +54,12 @@ module Koala
           self.fb_error_user_msg = error_info["error_user_msg"]
           self.fb_error_user_title = error_info["error_user_title"]
 
+          self.fb_error_trace_id = error_info["x-fb-trace-id"]
+          self.fb_error_debug = error_info["x-fb-debug"]
+          self.fb_error_rev = error_info["x-fb-rev"]
+
           error_array = []
-          %w(type code error_subcode message error_user_title error_user_msg).each do |key|
+          %w(type code error_subcode message error_user_title error_user_msg x-fb-trace-id).each do |key|
             error_array << "#{key}: #{error_info[key]}" if error_info[key]
           end
 

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -13,8 +13,17 @@ module Koala
     # Facebook responded with an error to an API request. If the exception contains a nil
     # http_status, then the error was detected before making a call to Facebook. (e.g. missing access token)
     class APIError < ::Koala::KoalaError
-      attr_accessor :fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message,
-                    :fb_error_user_msg, :fb_error_user_title, :fb_error_trace_id, :fb_error_debug, :fb_error_rev, :http_status, :response_body
+      attr_accessor :http_status,
+                    :response_body,
+                    :fb_error_type,
+                    :fb_error_code,
+                    :fb_error_subcode,
+                    :fb_error_message,
+                    :fb_error_user_msg,
+                    :fb_error_user_title,
+                    :fb_error_trace_id,
+                    :fb_error_debug,
+                    :fb_error_rev
 
       # Create a new API Error
       #

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -5,7 +5,7 @@ describe Koala::Facebook::APIError do
     expect(Koala::Facebook::APIError.new(nil, nil)).to be_a(Koala::KoalaError)
   end
 
-  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :fb_error_user_msg, :fb_error_user_title, :http_status, :response_body].each do |accessor|
+  [:fb_error_type, :fb_error_code, :fb_error_subcode, :fb_error_message, :fb_error_user_msg, :fb_error_user_title, :fb_error_trace_id, :fb_error_rev, :fb_error_debug, :http_status, :response_body].each do |accessor|
     it "has an accessor for #{accessor}" do
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(accessor)
       expect(Koala::Facebook::APIError.instance_methods.map(&:to_sym)).to include(:"#{accessor}=")
@@ -29,7 +29,10 @@ describe Koala::Facebook::APIError do
         'code' => 1,
         'error_subcode' => 'subcode',
         'error_user_msg' => 'error user message',
-        'error_user_title' => 'error user title'
+        'error_user_title' => 'error user title',
+        'x-fb-trace-id' => 'fb trace id',
+        'x-fb-debug' => 'fb debug token',
+        'x-fb-rev' => 'fb revision'
       }
       Koala::Facebook::APIError.new(400, '', error_info)
     }
@@ -40,7 +43,10 @@ describe Koala::Facebook::APIError do
       :fb_error_code => 1,
       :fb_error_subcode => 'subcode',
       :fb_error_user_msg => 'error user message',
-      :fb_error_user_title => 'error user title'
+      :fb_error_user_title => 'error user title',
+      :fb_error_trace_id => 'fb trace id',
+      :fb_error_debug => 'fb debug token',
+      :fb_error_rev => 'fb revision'
     }.each_pair do |accessor, value|
       it "sets #{accessor} to #{value}" do
         expect(error.send(accessor)).to eq(value)
@@ -48,7 +54,7 @@ describe Koala::Facebook::APIError do
     end
 
     it "sets the error message appropriately" do
-      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_msg: error user message [HTTP 400]")
+      expect(error.message).to eq("type: type, code: 1, error_subcode: subcode, message: message, error_user_title: error user title, error_user_msg: error user message, x-fb-trace-id: fb trace id [HTTP 400]")
     end
   end
 

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -401,30 +401,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
             }.to raise_exception(Koala::Facebook::BadFacebookResponse)
           end
 
-          context "with the old style" do
-            before :each do
-              allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(400, '{"error_code":190,"error_description":"Error validating access token."}', {}))
-            end
-
-            it "throws an error" do
-              expect {
-                Koala::Facebook::API.new("foo").batch {|batch_api| batch_api.get_object('me') }
-              }.to raise_exception(Koala::Facebook::APIError)
-            end
-
-            it "passes all the error details" do
-              begin
-                Koala::Facebook::API.new("foo").batch {|batch_api| batch_api.get_object('me') }
-              rescue Koala::Facebook::APIError => err
-                expect(err.fb_error_code).to eq(190)
-                expect(err.fb_error_message).to eq("Error validating access token.")
-                err.http_status == 400
-                err.response_body == '{"error_code":190,"error_description":"Error validating access token."}'
-              end
-            end
-          end
-
-          context "with the new style" do
+          context "with error info" do
             before :each do
               allow(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(400, '{"error":{"message":"Request 0 cannot depend on an  unresolved request with  name f. Requests can only depend on preceding requests","type":"GraphBatchException"}}', {}))
             end

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+module Koala
+  module Facebook
+    RSpec.describe GraphErrorChecker do
+      it "defines a set of AUTHENTICATION_ERROR_CODES" do
+        expect(GraphErrorChecker::AUTHENTICATION_ERROR_CODES).to match_array([102, 190, 450, 452, 2500])
+      end
+
+      it "defines a set of DEBUG_HEADERS" do
+        expect(GraphErrorChecker::DEBUG_HEADERS).to match_array([
+          "x-fb-rev",
+          "x-fb-debug",
+          "x-fb-trace-id"
+        ])
+      end
+
+      describe "#error_if_appropriate" do
+        shared_examples_for :returning_no_error do |status|
+          it "returns no error" do
+            expect(GraphErrorChecker.new(status, "{}", {}).error_if_appropriate).to be_nil
+          end
+
+          it "ignores error data even if present" do
+            checker = GraphErrorChecker.new(
+              status,
+              {"error" => {"some" => "error"}},
+              {"x-fb-rev" => "data"}
+            )
+            expect(checker.error_if_appropriate).to be_nil
+          end
+        end
+
+        context "if the status is 2xx" do
+          it_should_behave_like :returning_no_error, 202
+        end
+
+        context "if the status is 3xx" do
+          it_should_behave_like :returning_no_error, 302
+        end
+
+        shared_examples_for :returns_an_error do |status|
+          let(:body) { "{}" }
+          let(:headers) { {} }
+          let(:error) { GraphErrorChecker.new(status, body, headers).error_if_appropriate }
+          it "returns a ClientError for a generic error" do
+            expect(error).to be_a(ClientError)
+            expect(error.response_body).to eq(body)
+          end
+
+          it "returns a ClientError even if the body can't be parsed as JSON" do
+            body.replace("hello from Chicago")
+            expect(error).to be_a(ClientError)
+            expect(error.response_body).to eq(body)
+          end
+
+          it "adds error data from the body" do
+            error_data = {
+              "type" => "FB error type",
+              "code" => "FB error code",
+              "error_subcode" => "FB error subcode",
+              "message" => "An error occurred!",
+              "error_user_msg" => "A user msg",
+              "error_user_title" => "usr title"
+            }
+            body.replace({"error" => error_data}.to_json)
+
+            expect(error.fb_error_type).to eq(error_data["type"])
+            expect(error.fb_error_code).to eq(error_data["code"])
+            expect(error.fb_error_subcode).to eq(error_data["error_subcode"])
+            expect(error.fb_error_message).to eq(error_data["message"])
+            expect(error.fb_error_user_msg).to eq(error_data["error_user_msg"])
+            expect(error.fb_error_user_title).to eq(error_data["error_user_title"])
+          end
+
+          it "adds the FB debug headers to the errors" do
+            headers.merge!(
+              "x-fb-debug" => double("fb debug"),
+              "x-fb-rev" => double("fb rev"),
+              "x-fb-trace-id" => double("fb trace id"),
+            )
+            expect(error.fb_error_trace_id).to eq(headers["x-fb-trace-id"])
+            expect(error.fb_error_debug).to eq(headers["x-fb-debug"])
+            expect(error.fb_error_rev).to eq(headers["x-fb-rev"])
+          end
+
+          context "it returns an AuthenticationError" do
+            it "if FB says it's an OAuthException and it has no code" do
+              body.replace({"error" => {"type" => "OAuthException"}}.to_json)
+              expect(error).to be_an(AuthenticationError)
+            end
+
+            GraphErrorChecker::AUTHENTICATION_ERROR_CODES.each do |error_code|
+              it "if FB says it's an OAuthException and it has code #{error_code}" do
+                body.replace({"error" => {"type" => "OAuthException", "code" => error_code}}.to_json)
+                expect(error).to be_an(AuthenticationError)
+              end
+            end
+          end
+
+          # Note: I'm not sure why this behavior was implemented, it may be incorrect. To
+          # investigate.
+          it "doesn't return an AuthenticationError if FB says it's an OAuthException but the code doesn't match" do
+            body.replace({"error" => {"type" => "OAuthException", "code" => 2499}}.to_json)
+            expect(error).to be_an(ClientError)
+          end
+        end
+
+        context "if the status is 4xx" do
+          it_should_behave_like :returns_an_error, 400
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Pull request #502 adds FB error header information to the Koala exceptions (thanks @elhu!). This pull request includes that commit (for Github status checks) and additionally refactors the Graph API error handling into its own class, making it easier to read and comprehensively tested.