### PR TITLE
Use JSON stdlib and remove dependency on MultiJson

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["readme.md", "changelog.md"]
   gem.rdoc_options     = ["--line-numbers", "--inline-source", "--title", "Koala"]
 
-  gem.add_runtime_dependency("multi_json", ">= 1.3.0")
   gem.add_runtime_dependency("faraday")
   gem.add_runtime_dependency("addressable")
 end

--- a/lib/koala.rb
+++ b/lib/koala.rb
@@ -1,6 +1,6 @@
 # useful tools
 require 'digest/md5'
-require 'multi_json'
+require 'json'
 
 # include koala modules
 require 'koala/errors'

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -84,9 +84,10 @@ module Koala
           component == :response ? result : result.send(options[:http_component])
         else
           # parse the body as JSON and run it through the error checker (if provided)
-          # Note: Facebook sometimes sends results like "true" and "false", which aren't strictly objects
-          # and cause MultiJson.load to fail -- so we account for that by wrapping the result in []
-          MultiJson.load("[#{result.body.to_s}]")[0]
+          # Note: Facebook sometimes sends results like "true" and "false", which are valid[RFC7159]
+          # but unsupported by Ruby's stdlib[RFC4627] and cause JSON.load to fail -- so we account for
+          # that by wrapping the result in []
+          JSON.load("[#{result.body.to_s}]")[0]
         end
       end
 

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -274,7 +274,7 @@ module Koala
       # @return (see #put_connections)
       def put_wall_post(message, attachment = {}, target_id = "me", options = {}, &block)
         if properties = attachment.delete(:properties) || attachment.delete("properties")
-          properties = MultiJson.dump(properties) if properties.is_a?(Hash) || properties.is_a?(Array)
+          properties = JSON.dump(properties) if properties.is_a?(Hash) || properties.is_a?(Array)
           attachment["properties"] = properties
         end
         put_connections(target_id, "feed", attachment.merge({:message => message}), options, &block)
@@ -376,7 +376,7 @@ module Koala
       #
       # @return a hash of FQL results keyed to the appropriate query
       def fql_multiquery(queries = {}, args = {}, options = {}, &block)
-        resolved_results = if results = get_object("fql", args.merge(:q => MultiJson.dump(queries)), options)
+        resolved_results = if results = get_object("fql", args.merge(:q => JSON.dump(queries)), options)
           # simplify the multiquery result format
           results.inject({}) {|outcome, data| outcome[data["name"]] = data["fql_result_set"]; outcome}
         end
@@ -441,7 +441,7 @@ module Koala
       # @param options (see #get_object)
       # @param block (see Koala::Facebook::API#api)
       def set_app_restrictions(app_id, restrictions_hash, args = {}, options = {}, &block)
-        graph_call(app_id, args.merge(:restrictions => MultiJson.dump(restrictions_hash)), "post", options, &block)
+        graph_call(app_id, args.merge(:restrictions => JSON.dump(restrictions_hash)), "post", options, &block)
       end
 
       # Certain calls such as {#get_connections} return an array of results which you can page through

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -44,7 +44,7 @@ module Koala
         return [] unless batch_calls.length > 0
         # Turn the call args collected into what facebook expects
         args = {}
-        args["batch"] = MultiJson.dump(batch_calls.map { |batch_op|
+        args["batch"] = JSON.dump(batch_calls.map { |batch_op|
           args.merge!(batch_op.files) if batch_op.files
           batch_op.to_batch_params(access_token, app_secret)
         })
@@ -75,7 +75,7 @@ module Koala
                 raw_result = error
               else
                 # (see note in regular api method about JSON parsing)
-                body = MultiJson.load("[#{call_result['body'].to_s}]")[0]
+                body = JSON.load("[#{call_result['body'].to_s}]")[0]
 
                 # Get the HTTP component they want
                 raw_result = case batch_op.http_options[:http_component]

--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -61,8 +61,8 @@ module Koala
         # Normally, we start with the response body. If it isn't valid JSON, we start with an empty
         # hash and fill it with error data.
         @response_hash ||= begin
-          MultiJson.load(body)
-        rescue MultiJson::DecodeError
+          JSON.load(body)
+        rescue JSON::ParserError
           {}
         end
       end

--- a/lib/koala/api/rest_api.rb
+++ b/lib/koala/api/rest_api.rb
@@ -20,7 +20,7 @@ module Koala
       # @return true if successful, false if not.  (This call currently doesn't give useful feedback on failure.)
       def set_app_properties(properties, args = {}, options = {})
         raise AuthenticationError.new(nil, nil, "setAppProperties requires an access token") unless @access_token
-        rest_call("admin.setAppProperties", args.merge(:properties => MultiJson.dump(properties)), options, "post")
+        rest_call("admin.setAppProperties", args.merge(:properties => JSON.dump(properties)), options, "post")
       end
 
       # Make a call to the REST API. 
@@ -44,8 +44,8 @@ module Koala
           # check for REST API-specific errors
           if response.status >= 400
             begin
-              response_hash = MultiJson.load(response.body)
-            rescue MultiJson::DecodeError
+              response_hash = JSON.load(response.body)
+            rescue JSON::ParserError
               response_hash = {}
             end
 

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -50,7 +50,7 @@ module Koala
         else
           unless error_info
             begin
-              error_info = MultiJson.load(response_body)['error'] if response_body
+              error_info = JSON.load(response_body)['error'] if response_body
             rescue
             end
             error_info ||= {}

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -130,7 +130,7 @@ module Koala
     # @return the appropriately-encoded string
     def self.encode_params(param_hash)
       ((param_hash || {}).sort_by{|k, v| k.to_s}.collect do |key_and_value|
-        key_and_value[1] = MultiJson.dump(key_and_value[1]) unless key_and_value[1].is_a? String
+        key_and_value[1] = JSON.dump(key_and_value[1]) unless key_and_value[1].is_a? String
         "#{key_and_value[0].to_s}=#{CGI.escape key_and_value[1]}"
       end).join("&")
     end

--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -134,7 +134,7 @@ module Koala
         if response == ''
           raise BadFacebookResponse.new(200, '', 'generate_client_code received an error: empty response body')
         else
-          result = MultiJson.load(response)
+          result = JSON.load(response)
         end
 
         result.has_key?('code') ? result['code'] : raise(Koala::KoalaError.new("Facebook returned a valid response without the expected 'code' in the body (response = #{response})"))
@@ -240,7 +240,7 @@ module Koala
         raise OAuthSignatureError, 'Invalid (incomplete) signature data' unless encoded_sig && encoded_envelope
 
         signature = base64_url_decode(encoded_sig).unpack("H*").first
-        envelope = MultiJson.load(base64_url_decode(encoded_envelope))
+        envelope = JSON.load(base64_url_decode(encoded_envelope))
 
         raise OAuthSignatureError, "Unsupported algorithm #{envelope['algorithm']}" if envelope['algorithm'] != 'HMAC-SHA256'
 
@@ -260,8 +260,8 @@ module Koala
       end
 
       def parse_access_token(response_text)
-        MultiJson.load(response_text)
-      rescue MultiJson::LoadError
+        JSON.load(response_text)
+      rescue JSON::ParserError
         response_text.split("&").inject({}) do |hash, bit|
           key, value = bit.split("=")
           hash.merge!(key => value)

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -128,7 +128,7 @@ describe "Koala::Facebook::API" do
     allow(Koala).to receive(:make_request).and_return(response)
 
     json_body = double('JSON body')
-    allow(MultiJson).to receive(:load).and_return([json_body])
+    allow(JSON).to receive(:load).and_return([json_body])
 
     expect(@service.api('anything')).to eq(json_body)
   end

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -322,7 +322,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           allow(Koala::Facebook::GraphBatchAPI::BatchOperation).to receive(:new).and_return(op)
 
           # two requests should generate two batch operations
-          expected = MultiJson.dump([op.to_batch_params(access_token, nil), op.to_batch_params(access_token, nil)])
+          expected = JSON.dump([op.to_batch_params(access_token, nil), op.to_batch_params(access_token, nil)])
           expect(Koala).to receive(:make_request).with(anything, hash_including("batch" => expected), anything, anything).and_return(@fake_response)
           Koala::Facebook::API.new(access_token).batch do |batch_api|
             batch_api.get_object('me')

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -141,7 +141,7 @@ describe Koala::HTTPService do
       val = 'json_value'
       not_a_string = 'not_a_string'
       allow(not_a_string).to receive(:is_a?).and_return(false)
-      expect(MultiJson).to receive(:dump).with(not_a_string).and_return(val)
+      expect(JSON).to receive(:dump).with(not_a_string).and_return(val)
 
       string = "hi"
 

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -401,7 +401,7 @@ describe "Koala::Facebook::OAuth" do
           allow(Koala).to receive(:make_request).and_return(
             Koala::HTTPService::Response.new(
               200,
-              MultiJson.dump(result),
+              JSON.dump(result),
               {}
             )
           )
@@ -584,7 +584,7 @@ describe "Koala::Facebook::OAuth" do
       # the signed request code is ported directly from Facebook
       # so we only need to test at a high level that it works
       it "throws an error if the algorithm is unsupported" do
-        allow(MultiJson).to receive(:load).and_return("algorithm" => "my fun algorithm")
+        allow(JSON).to receive(:load).and_return("algorithm" => "my fun algorithm")
         expect { @oauth.parse_signed_request(@signed_params) }.to raise_error(Koala::Facebook::OAuthSignatureError)
       end
 

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -74,58 +74,58 @@ graph_api:
         no_token: '{"facebook":"{}","koppel":"{}"}'
 
     # Ruby 1.8.7 and 1.9.2 generate JSON with different key ordering, hence we have to dynamically generate it here
-    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "koppel"}]) %>:
+    batch=<%= JSON.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "koppel"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"id\":\"123\"}"}, {"code": 200, "body":"{\"id\":\"456\"}"}]'
-    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/picture"}]) %>:
+    batch=<%= JSON.dump([{"method" => "get", "relative_url" => "me/picture"}]) %>:
       post:
         with_token: '[{"code": 302, "headers":[{"name":"Location","value":"http://google.com"}]}]'
-    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/picture?redirect=false"}]) %>:
+    batch=<%= JSON.dump([{"method" => "get", "relative_url" => "me/picture?redirect=false"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"data\":{\"is_silhouette\":false,\"url\":\"http:\/\/google.com\"}}"}]'
-    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "me/friends"}]) %>:
+    batch=<%= JSON.dump([{"method" => "get", "relative_url" => "me"},{"method" => "get", "relative_url" => "me/friends"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"id\":\"koppel\"}"}, {"code": 200, "body":"{\"data\":[{\"id\":\"lukeshepard\"}],\"paging\":{}}"}]'
-    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"me"}, {"method"=>"get", "relative_url"=>"#{OAUTH_DATA["app_id"]}/insights?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
+    batch=<%= JSON.dump([{"method"=>"get", "relative_url"=>"me"}, {"method"=>"get", "relative_url"=>"#{OAUTH_DATA["app_id"]}/insights?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"id\":\"123\"}"}, {"code": 200, "body":"{\"data\":[],\"paging\":{}}"}]'
-    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"2/invalidconnection"}, {"method"=>"get", "relative_url"=>"koppel?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
+    batch=<%= JSON.dump([{"method"=>"get", "relative_url"=>"2/invalidconnection"}, {"method"=>"get", "relative_url"=>"koppel?access_token=#{CGI.escape APP_ACCESS_TOKEN}"}]) %>:
       post:
         with_token: '[{"code": 400, "body": "{\"error\":{\"type\":\"AnError\", \"message\":\"An error occurred!.\"}}"},{"code": 200, "body":"{\"id\":\"123\"}"}]'
-    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"FEED_ITEM_BATCH/likes"}, {"method"=>"delete", "relative_url"=> "FEED_ITEM_BATCH"}]) %>:
+    batch=<%= JSON.dump([{"method"=>"post", "relative_url"=>"FEED_ITEM_BATCH/likes"}, {"method"=>"delete", "relative_url"=> "FEED_ITEM_BATCH"}]) %>:
       post:
         with_token: '[{"code": 200, "body": "{\"id\": \"MOCK_LIKE\"}"},{"code": 200, "body":true}]'
-    batch=<%= MultiJson.dump([{"method" => "post", "relative_url" => "method/fql.query", "body" => "query=select+first_name+from+user+where+uid%3D2905623"}]) %>:
+    batch=<%= JSON.dump([{"method" => "post", "relative_url" => "method/fql.query", "body" => "query=select+first_name+from+user+where+uid%3D2905623"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"[{\"first_name\":\"Alex\"}]"}]'
 
     # dependencies
-    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"me", "name" => "getme"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getme"}]) %>:
+    batch=<%= JSON.dump([{"method"=>"get", "relative_url"=>"me", "name" => "getme"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getme"}]) %>:
       post:
         with_token: '[null,{"code": 200, "body":"{\"id\":\"123\"}"}]'
-    batch=<%= MultiJson.dump([{"method"=>"get", "relative_url"=>"2/invalidconnection", "name" => "getdata"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getdata"}]) %>:
+    batch=<%= JSON.dump([{"method"=>"get", "relative_url"=>"2/invalidconnection", "name" => "getdata"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getdata"}]) %>:
       post:
         with_token: '[{"code": 400, "body": "{\"error\":{\"type\":\"AnError\", \"message\":\"An error occurred!.\"}}"},null]'
-    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
+    batch=<%= JSON.dump([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
       post:
         with_token: '[null,{"code": 200, "body":"{}"}]'
-    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends", "omit_response_on_success" => false}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
+    batch=<%= JSON.dump([{"method" => "get", "relative_url" => "me/friends?limit=5", "name" => "get-friends", "omit_response_on_success" => false}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=get-friends:$.data.*.id}"}"}]) %>:
       post:
         with_token: '[{"code": 200, "body":"{\"data\":[],\"paging\":{}}"},{"code": 200, "body":"{}"}]'
-    batch=<%= MultiJson.dump([{"method" => "get", "relative_url" => "me/friends?limit=5"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=i-dont-exist:$.data.*.id}"}"}]) %>:
+    batch=<%= JSON.dump([{"method" => "get", "relative_url" => "me/friends?limit=5"}, {"method" => "get", "relative_url" => "?ids=#{CGI.escape "{result=i-dont-exist:$.data.*.id}"}"}]) %>:
       post:
         with_token:
           code: 400
           body: '{"error_code":190,"error_description":"Error validating access token."}'
 
     # attached files tests
-    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
+    batch=<%= JSON.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
       post:
         with_token: '[{"code": 400, body": "{\"error\":{\"type\":\"AnError\", \"message\":\"An error occurred!.\"}}"},null]'
-    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
+    batch=<%= JSON.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}]) %>&op1_file0=[FILE]:
       post:
         with_token: '[{"code": 200, "body":"{\"id\": \"MOCK_PHOTO\"}"}]'
-    batch=<%= MultiJson.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}, {"method"=>"post", "relative_url"=>"koppel/photos", "attached_files" => "op2_file0"}]) %>&op1_file0=[FILE]&op2_file0=[FILE]:
+    batch=<%= JSON.dump([{"method"=>"post", "relative_url"=>"me/photos", "attached_files" => "op1_file0"}, {"method"=>"post", "relative_url"=>"koppel/photos", "attached_files" => "op2_file0"}]) %>&op1_file0=[FILE]&op2_file0=[FILE]:
       post:
         with_token: '[{"code": 200, "body":"{\"id\": \"MOCK_PHOTO\"}"}, {"code": 200, "body":"{\"id\": \"MOCK_PHOTO\"}"}]'
 
@@ -166,7 +166,7 @@ graph_api:
     link=http://oauth.twoalex.com/&message=Hello, world, from the test suite again!&name=OAuth Playground:
       post:
         with_token: '{"id": "FEED_ITEM_CONTEXT"}'
-    link=http://oauth.twoalex.com/&message=body&name=It's a big question&picture=http://oauth.twoalex.com//images/logo.png&properties=<%= MultiJson.encode({"Link1"=>{"text"=>"Left", "href"=>"http://oauth.twoalex.com/"}, "other" => {"text"=>"Straight ahead", "href"=>"http://oauth.twoalex.com/?"}}) %>&type=link:
+    link=http://oauth.twoalex.com/&message=body&name=It's a big question&picture=http://oauth.twoalex.com//images/logo.png&properties=<%= JSON.dump({"Link1"=>{"text"=>"Left", "href"=>"http://oauth.twoalex.com/"}, "other" => {"text"=>"Straight ahead", "href"=>"http://oauth.twoalex.com/?"}}) %>&type=link:
       post:
         with_token: '{"id": "FEED_ITEM_DICTIONARY"}'
 
@@ -302,11 +302,11 @@ graph_api:
       get:
         <<: *token_required
         with_token: '[{"read_stream":1}]'
-    'q=<%= MultiJson.dump({"query1" => "select post_id from stream where source_id = me()", "query2" => "select fromid from comment where post_id in (select post_id from #query1)", "query3" => "select uid, name from user where uid in (select fromid from #query2)"}) %>':
+    'q=<%= JSON.dump({"query1" => "select post_id from stream where source_id = me()", "query2" => "select fromid from comment where post_id in (select post_id from #query1)", "query3" => "select uid, name from user where uid in (select fromid from #query2)"}) %>':
       get:
         <<: *token_required
         with_token: '[{"name":"query1", "fql_result_set":[]},{"name":"query2", "fql_result_set":[]},{"name":"query3", "fql_result_set":[]}]'
-    'q=<%= MultiJson.dump({"query1" => "select uid, first_name from user where uid = 2901279", "query2" => "select uid, first_name from user where uid = 2905623"}) %>':
+    'q=<%= JSON.dump({"query1" => "select uid, first_name from user where uid = 2901279", "query2" => "select uid, first_name from user where uid = 2905623"}) %>':
       get:
         with_token: '[{"name":"query1", "fql_result_set":[{"uid":2901279,"first_name":"Luke"}]},{"name":"query2", "fql_result_set":[{"uid":"2905623","first_name":"Alex"}]}]'
         no_token: '[{"name":"query1", "fql_result_set":[{"uid":2901279,"first_name":"Luke"}]},{"name":"query2", "fql_result_set":[{"uid":"2905623","first_name":"Alex"}]}]'
@@ -325,7 +325,7 @@ graph_api:
 
 
   '/<%= APP_ID %>':
-    restrictions=<%= MultiJson.dump({"age_distr" => "13+"}) %>:
+    restrictions=<%= JSON.dump({"age_distr" => "13+"}) %>:
       post:
         with_token: "true"
 

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -188,7 +188,7 @@ shared_examples_for "Koala GraphAPI" do
     it "passes a queries argument" do
       queries = double('query string')
       queries_json = "some JSON"
-      allow(MultiJson).to receive(:dump).with(queries).and_return(queries_json)
+      allow(JSON).to receive(:dump).with(queries).and_return(queries_json)
 
       expect(@api).to receive(:get_object).with(anything, hash_including(:q => queries_json), anything)
       @api.fql_multiquery(queries)
@@ -485,7 +485,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
     end
 
     it "JSON-encodes the restrictions" do
-      expect(@app_api).to receive(:graph_call).with(anything, hash_including(:restrictions => MultiJson.dump(@restrictions)), anything, anything)
+      expect(@app_api).to receive(:graph_call).with(anything, hash_including(:restrictions => JSON.dump(@restrictions)), anything, anything)
       @app_api.set_app_restrictions(KoalaTest.app_id, @restrictions)
     end
 

--- a/spec/support/koala_test.rb
+++ b/spec/support/koala_test.rb
@@ -243,7 +243,7 @@ module KoalaTest
           require 'typhoeus/adapters/faraday' if adapter.to_s == "typhoeus"
           Faraday.default_adapter = adapter.to_sym
         end
-      rescue LoadError
+      rescue ParserError
         puts "Unable to load adapter #{adapter}, using Net::HTTP."
       ensure
         @adapter_activation_attempted = true

--- a/spec/support/mock_http_service.rb
+++ b/spec/support/mock_http_service.rb
@@ -5,9 +5,6 @@ module Koala
   module MockHTTPService
     include Koala::HTTPService
 
-    # fix our specs to use ok_json, so we always get the same results from to_json
-    MultiJson.use :ok_json
-
     # Mocks all HTTP requests for with koala_spec_with_mocks.rb
     # Mocked values to be included in TEST_DATA used in specs
     ACCESS_TOKEN = '*'
@@ -91,7 +88,7 @@ module Koala
       args = arguments.inject({}) do |hash, (k, v)|
         # ensure our args are all stringified
         value = if v.is_a?(String)
-          should_json_decode?(v) ? MultiJson.load(v) : v
+          should_json_decode?(v) ? JSON.load(v) : v
         elsif v.is_a?(Koala::UploadableIO)
           # obviously there are no files in the yaml
           "[FILE]"
@@ -122,7 +119,7 @@ module Koala
         # will remove +'s in restriction strings
         string.split("&").reduce({}) do |hash, component|
           k, v = component.split("=", 2) # we only care about the first =
-          value = should_json_decode?(v) ? MultiJson.decode(v) : v.to_s rescue v.to_s
+          value = should_json_decode?(v) ? JSON.load(v) : v.to_s rescue v.to_s
           # some special-casing, unfortunate but acceptable in this testing
           # environment
           value = nil if value.empty?

--- a/spec/support/rest_api_shared_examples.rb
+++ b/spec/support/rest_api_shared_examples.rb
@@ -126,7 +126,7 @@ shared_examples_for "Koala RestAPI with an access token" do
   describe "#set_app_properties" do
     it "sends Facebook the properties JSON-encoded as :properties" do
       props = {:a => 2, :c => [1, 2, "d"]}
-      expect(@api).to receive(:rest_call).with(anything, hash_including(:properties => MultiJson.dump(props)), anything, anything)
+      expect(@api).to receive(:rest_call).with(anything, hash_including(:properties => JSON.dump(props)), anything, anything)
       @api.set_app_properties(props)
     end
 


### PR DESCRIPTION
JSON is part of Ruby since MRI 1.9+.  Are there any reason to use multi_json nowadays? (e.g. Some Ruby implementations lack bundled JSON library)

See http://www.mikeperham.com/2016/02/09/kill-your-dependencies/ for my naive rationale.