### PR TITLE
Reduce complexity of graph batch api

### DIFF
--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -18,7 +18,7 @@ module Koala
         @batch_calls ||= []
       end
 
-      def graph_call_in_batch(path, args = {}, verb = "get", options = {}, &post_processing)
+      def graph_call_in_batch(path, args = {}, verb = 'get', options = {}, &post_processing)
         # normalize options for consistency
         options = Koala::Utils.symbolize_hash(options)
 
@@ -82,7 +82,7 @@ module Koala
 
       def bad_response
         # Facebook sometimes reportedly returns an empty body at times
-        BadFacebookResponse.new(200, '', "Facebook returned an empty body")
+        BadFacebookResponse.new(200, '', 'Facebook returned an empty body')
       end
 
       def result_from_response(response, options)
@@ -134,7 +134,7 @@ module Koala
 
         # Get the HTTP component they want
         case component
-        when :status  then response["code"].to_i
+        when :status  then response['code'].to_i
         # facebook returns the headers as an array of k/v pairs, but we want a regular hash
         when :headers then headers
         # (see note in regular api method about JSON parsing)

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -53,7 +53,7 @@ module Koala
       end
 
       def handle_response
-        -> (response) do
+        lambda do (response)
           raise bad_response if response.nil?
           response.map(&generate_results)
         end
@@ -61,7 +61,7 @@ module Koala
 
       def generate_results
         index = 0
-        -> (call_result) do
+        lambda do (call_result)
           batch_op     = batch_calls[index]; index += 1
           post_process = batch_op.post_processing
 

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -44,11 +44,10 @@ module Koala
         return [] if batch_calls.empty?
 
         # Turn the call args collected into what facebook expects
-        args = {}
-        args["batch"] = JSON.dump(batch_calls.map { |batch_op|
-          args.merge!(batch_op.files) if batch_op.files
-          batch_op.to_batch_params(access_token, app_secret)
-        })
+        args = { 'batch' => batch_args }
+        batch_calls.each do |call|
+          args.merge! call.files || {}
+        end
 
         batch_result = graph_call_outside_batch('/', args, 'post', http_options) do |response|
           unless response
@@ -103,6 +102,13 @@ module Koala
         end
       end
 
+      def batch_args
+        calls = batch_calls.map do |batch_op|
+          batch_op.to_batch_params(access_token, app_secret)
+        end
+
+        JSON.dump calls
+      end
     end
   end
 end

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -41,7 +41,8 @@ module Koala
 
       # execute the queued batch calls
       def execute(http_options = {})
-        return [] unless batch_calls.length > 0
+        return [] if batch_calls.empty?
+
         # Turn the call args collected into what facebook expects
         args = {}
         args["batch"] = JSON.dump(batch_calls.map { |batch_op|

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -53,7 +53,7 @@ module Koala
       end
 
       def handle_response
-        lambda do (response)
+        lambda do |response|
           raise bad_response if response.nil?
           response.map(&generate_results)
         end
@@ -61,7 +61,7 @@ module Koala
 
       def generate_results
         index = 0
-        lambda do (call_result)
+        lambda do |call_result|
           batch_op     = batch_calls[index]; index += 1
           post_process = batch_op.post_processing
 


### PR DESCRIPTION
I'm not sure if you would like to reduce some of the complexity of the file, but I'm issuing this pull request in support of that cause :)

First: I'm reducing total line count per method and breaking each procedure into smaller consumable methods.

Second: Current iteration is Ruby 1.9+ (Enumerable#each_with_object, Enumerator#with_index, etc.)

_All tests pass_
