### PR TITLE
Use JSON.parse instead of JSON.load

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -85,9 +85,9 @@ module Koala
         else
           # parse the body as JSON and run it through the error checker (if provided)
           # Note: Facebook sometimes sends results like "true" and "false", which are valid[RFC7159]
-          # but unsupported by Ruby's stdlib[RFC4627] and cause JSON.load to fail -- so we account for
+          # but unsupported by Ruby's stdlib[RFC4627] and cause JSON.parse to fail -- so we account for
           # that by wrapping the result in []
-          JSON.load("[#{result.body.to_s}]")[0]
+          JSON.parse("[#{result.body.to_s}]")[0]
         end
       end
 

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -75,7 +75,7 @@ module Koala
                 raw_result = error
               else
                 # (see note in regular api method about JSON parsing)
-                body = JSON.load("[#{call_result['body'].to_s}]")[0]
+                body = JSON.parse("[#{call_result['body'].to_s}]")[0]
 
                 # Get the HTTP component they want
                 raw_result = case batch_op.http_options[:http_component]

--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -61,7 +61,7 @@ module Koala
         # Normally, we start with the response body. If it isn't valid JSON, we start with an empty
         # hash and fill it with error data.
         @response_hash ||= begin
-          JSON.load(body)
+          JSON.parse(body)
         rescue JSON::ParserError
           {}
         end

--- a/lib/koala/api/rest_api.rb
+++ b/lib/koala/api/rest_api.rb
@@ -5,14 +5,14 @@ module Koala
     # in the future, the REST API will be deprecated.
     # For now, though, there are a few methods that can't be done through the Graph API.
     #
-    # When using the REST API, Koala will use Facebook's faster read-only servers 
-    # whenever the call allows.  
+    # When using the REST API, Koala will use Facebook's faster read-only servers
+    # whenever the call allows.
     #
     # See https://github.com/arsduo/koala/wiki/REST-API for a general introduction to Koala
     # and the Rest API.
     module RestAPIMethods
       # Set a Facebook application's properties.
-      # 
+      #
       # @param properties a hash of properties you want to update with their new values.
       # @param (see #rest_call)
       # @param options (see #rest_call)
@@ -23,17 +23,17 @@ module Koala
         rest_call("admin.setAppProperties", args.merge(:properties => JSON.dump(properties)), options, "post")
       end
 
-      # Make a call to the REST API. 
+      # Make a call to the REST API.
       #
       # @note The order of the last two arguments is non-standard (for historical reasons).  Sorry.
-      # 
+      #
       # @param fb_method the API call you want to make
       # @param args (see Koala::Facebook::GraphAPIMethods#graph_call)
       # @param options (see Koala::Facebook::GraphAPIMethods#graph_call)
       # @param verb (see Koala::Facebook::GraphAPIMethods#graph_call)
-      # 
+      #
       # @raise [Koala::Facebook::APIError] if Facebook returns an error
-      # 
+      #
       # @return the result from Facebook
       def rest_call(fb_method, args = {}, options = {}, verb = "get")
         Koala::Utils.deprecate("The REST API is now deprecated; please use the equivalent Graph API methods instead.  See http://developers.facebook.com/blog/post/616/.")
@@ -44,7 +44,7 @@ module Koala
           # check for REST API-specific errors
           if response.status >= 400
             begin
-              response_hash = JSON.load(response.body)
+              response_hash = JSON.parse(response.body)
             rescue JSON::ParserError
               response_hash = {}
             end

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -50,7 +50,7 @@ module Koala
         else
           unless error_info
             begin
-              error_info = JSON.load(response_body)['error'] if response_body
+              error_info = JSON.parse(response_body)['error'] if response_body
             rescue
             end
             error_info ||= {}

--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -134,7 +134,7 @@ module Koala
         if response == ''
           raise BadFacebookResponse.new(200, '', 'generate_client_code received an error: empty response body')
         else
-          result = JSON.load(response)
+          result = JSON.parse(response)
         end
 
         result.has_key?('code') ? result['code'] : raise(Koala::KoalaError.new("Facebook returned a valid response without the expected 'code' in the body (response = #{response})"))
@@ -240,7 +240,7 @@ module Koala
         raise OAuthSignatureError, 'Invalid (incomplete) signature data' unless encoded_sig && encoded_envelope
 
         signature = base64_url_decode(encoded_sig).unpack("H*").first
-        envelope = JSON.load(base64_url_decode(encoded_envelope))
+        envelope = JSON.parse(base64_url_decode(encoded_envelope))
 
         raise OAuthSignatureError, "Unsupported algorithm #{envelope['algorithm']}" if envelope['algorithm'] != 'HMAC-SHA256'
 
@@ -260,7 +260,7 @@ module Koala
       end
 
       def parse_access_token(response_text)
-        JSON.load(response_text)
+        JSON.parse(response_text)
       rescue JSON::ParserError
         response_text.split("&").inject({}) do |hash, bit|
           key, value = bit.split("=")

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -128,7 +128,7 @@ describe "Koala::Facebook::API" do
     allow(Koala).to receive(:make_request).and_return(response)
 
     json_body = double('JSON body')
-    allow(JSON).to receive(:load).and_return([json_body])
+    allow(JSON).to receive(:parse).and_return([json_body])
 
     expect(@service.api('anything')).to eq(json_body)
   end

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -54,6 +54,12 @@ module Koala
             expect(error.response_body).to eq(body)
           end
 
+          it "returns a ClientError if the body is empty" do
+            body.replace("")
+            expect(error).to be_a(ClientError)
+            expect(error.response_body).to eq(body)
+          end
+
           it "adds error data from the body" do
             error_data = {
               "type" => "FB error type",
@@ -113,4 +119,3 @@ module Koala
     end
   end
 end
-

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -584,7 +584,7 @@ describe "Koala::Facebook::OAuth" do
       # the signed request code is ported directly from Facebook
       # so we only need to test at a high level that it works
       it "throws an error if the algorithm is unsupported" do
-        allow(JSON).to receive(:load).and_return("algorithm" => "my fun algorithm")
+        allow(JSON).to receive(:parse).and_return("algorithm" => "my fun algorithm")
         expect { @oauth.parse_signed_request(@signed_params) }.to raise_error(Koala::Facebook::OAuthSignatureError)
       end
 

--- a/spec/support/mock_http_service.rb
+++ b/spec/support/mock_http_service.rb
@@ -88,7 +88,7 @@ module Koala
       args = arguments.inject({}) do |hash, (k, v)|
         # ensure our args are all stringified
         value = if v.is_a?(String)
-          should_json_decode?(v) ? JSON.load(v) : v
+          should_json_decode?(v) ? JSON.parse(v) : v
         elsif v.is_a?(Koala::UploadableIO)
           # obviously there are no files in the yaml
           "[FILE]"
@@ -119,7 +119,7 @@ module Koala
         # will remove +'s in restriction strings
         string.split("&").reduce({}) do |hash, component|
           k, v = component.split("=", 2) # we only care about the first =
-          value = should_json_decode?(v) ? JSON.load(v) : v.to_s rescue v.to_s
+          value = should_json_decode?(v) ? JSON.parse(v) : v.to_s rescue v.to_s
           # some special-casing, unfortunate but acceptable in this testing
           # environment
           value = nil if value.empty?


### PR DESCRIPTION
JSON.parse and JSON.load behave slightly differently. With default options, JSON.load allows you to reference a Ruby class using `JSON.load('{"json_class": "EvilClass"}')`. This is bad with untrusted input.

With empty string JSON.load returns `nil`, whereas JSON.parse raises a parse error. Returning `nil` caused an exception in error handling code when server response body was an empty string.