### PR TITLE
Remove support for FQL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,10 @@
 v3.0.0
 ======
 
-Updated features:
+Removed features:
 
 * Removed the old Rest API, since Facebook doesn't support it (#568)
+* Removed support for FQL, which Facebook removed on August 8, 2016 (#569)
 
 Internal improvements:
 

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -359,45 +359,6 @@ module Koala
       # except to support cases where the Facebook API requires non-standard input
       # such as JSON-encoding arguments, posts directly to objects, etc.
 
-      # Make an FQL query.
-      # Convenience method equivalent to get_object("fql", :q => query).
-      #
-      # @param query the FQL query to perform
-      # @param args (see #get_object)
-      # @param options (see #get_object)
-      # @param block (see Koala::Facebook::API#api)
-      #
-      # @return the result of the FQL query.
-      def fql_query(query, args = {}, options = {}, &block)
-        get_object("fql", args.merge(:q => query), options, &block)
-      end
-
-      # Make an FQL multiquery.
-      # This method simplifies the result returned from multiquery into a more logical format.
-      #
-      # @param queries a hash of query names => FQL queries
-      # @param args (see #get_object)
-      # @param options (see #get_object)
-      # @param block (see Koala::Facebook::API#api)
-      #
-      # @example
-      #     @api.fql_multiquery({
-      #       "query1" => "select post_id from stream where source_id = me()",
-      #       "query2" => "select fromid from comment where post_id in (select post_id from #query1)"
-      #     })
-      #     # returns {"query1" => [obj1, obj2, ...], "query2" => [obj3, ...]}
-      #     # instead of [{"name":"query1", "fql_result_set":[]},{"name":"query2", "fql_result_set":[]}]
-      #
-      # @return a hash of FQL results keyed to the appropriate query
-      def fql_multiquery(queries = {}, args = {}, options = {}, &block)
-        resolved_results = if results = get_object("fql", args.merge(:q => queries.to_json), options)
-          # simplify the multiquery result format
-          results.inject({}) {|outcome, data| outcome[data["name"]] = data["fql_result_set"]; outcome}
-        end
-
-        block ? block.call(resolved_results) : resolved_results
-      end
-
       # Get a page's access token, allowing you to act as the page.
       # Convenience method for @api.get_object(page_id, :fields => "access_token").
       #
@@ -529,7 +490,7 @@ module Koala
       # @yield response when making a batch API call, you can pass in a block
       #        that parses the results, allowing for cleaner code.
       #        The block's return value is returned in the batch results.
-      #        See the code for {#get_picture} or {#fql_multiquery} for examples.
+      #        See the code for {#get_picture} for examples.
       #        (Not needed in regular calls; you'll probably rarely use this.)
       #
       # @raise [Koala::Facebook::APIError] if Facebook returns an error

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -577,16 +577,6 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
       end
     end
 
-    it "allows FQL" do
-      result = @api.batch do |batch_api|
-        batch_api.graph_call("method/fql.query", {:query=>"select first_name from user where uid=#{KoalaTest.user1_id}"}, "post")
-      end
-
-      fql_result = result[0]
-      expect(fql_result[0]).to be_a(Hash)
-      expect(fql_result[0]["first_name"]).to eq("Alex")
-    end
-
     describe 'with post-processing callback' do
       let(:me_result) { double("me result") }
       let(:friends_result) { [double("friends result")] }

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -35,25 +35,6 @@ describe 'Koala::Facebook::GraphAPIMethods' do
       end
     end
 
-    context '#fql_multiquery' do
-      before do
-        expect(@api).to receive(:get_object).and_return([
-          {"name" => "query1", "fql_result_set" => [{"id" => 123}]},
-          {"name" => "query2", "fql_result_set" => ["id" => 456]}
-        ])
-      end
-
-      it 'is called with resolved response' do
-        resolved_result = {
-          'query1' => [{'id' => 123}],
-          'query2' => [{'id' => 456}]
-        }
-        response = @api.fql_multiquery({}, &post_processing)
-        expect(response["args"]).to eq(resolved_result)
-        expect(response["result"]).to eq(result)
-      end
-    end
-
     context '#get_page_access_token' do
       it 'returns result of block' do
         token = Koala::MockHTTPService::APP_ACCESS_TOKEN

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -79,9 +79,6 @@ graph_api:
     batch=<%= JSON.dump([{"method"=>"post", "relative_url"=>"FEED_ITEM_BATCH/likes"}, {"method"=>"delete", "relative_url"=> "FEED_ITEM_BATCH"}]) %>:
       post:
         with_token: '[{"code": 200, "body": "{\"id\": \"MOCK_LIKE\"}"},{"code": 200, "body":true}]'
-    batch=<%= JSON.dump([{"method" => "post", "relative_url" => "method/fql.query", "body" => "query=select+first_name+from+user+where+uid%3D2905623"}]) %>:
-      post:
-        with_token: '[{"code": 200, "body":"[{\"first_name\":\"Alex\"}]"}]'
 
     # dependencies
     batch=<%= JSON.dump([{"method"=>"get", "relative_url"=>"me", "name" => "getme"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getme"}]) %>:
@@ -279,24 +276,6 @@ graph_api:
       get:
         with_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
         no_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
-
-  /fql:
-    q=select uid, first_name from user where uid = 2901279:
-      get:
-        no_token: '[{"uid":2901279,"first_name":"Luke"}]'
-        with_token: '[{"uid":2901279,"first_name":"Luke"}]'
-    q=select read_stream from permissions where uid = 2901279:
-      get:
-        <<: *token_required
-        with_token: '[{"read_stream":1}]'
-    'q=<%= JSON.dump({"query1" => "select post_id from stream where source_id = me()", "query2" => "select fromid from comment where post_id in (select post_id from #query1)", "query3" => "select uid, name from user where uid in (select fromid from #query2)"}) %>':
-      get:
-        <<: *token_required
-        with_token: '[{"name":"query1", "fql_result_set":[]},{"name":"query2", "fql_result_set":[]},{"name":"query3", "fql_result_set":[]}]'
-    'q=<%= JSON.dump({"query1" => "select uid, first_name from user where uid = 2901279", "query2" => "select uid, first_name from user where uid = 2905623"}) %>':
-      get:
-        with_token: '[{"name":"query1", "fql_result_set":[{"uid":2901279,"first_name":"Luke"}]},{"name":"query2", "fql_result_set":[{"uid":"2905623","first_name":"Alex"}]}]'
-        no_token: '[{"name":"query1", "fql_result_set":[{"uid":2901279,"first_name":"Luke"}]},{"name":"query2", "fql_result_set":[{"uid":"2905623","first_name":"Alex"}]}]'
 
 
   '/115349521819193_113815981982767':

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -158,61 +158,6 @@ shared_examples_for "Koala GraphAPI" do
     # the results should have an ID and a name, among other things
     expect(result["id"] && result["name"]).to be_truthy
   end
-
-  # FQL
-  describe "#fql_query" do
-    it "makes a request to /fql" do
-      expect(@api).to receive(:get_object).with("fql", anything, anything)
-      @api.fql_query double('query string')
-    end
-
-    it "passes a query argument" do
-      query = double('query string')
-      expect(@api).to receive(:get_object).with(anything, hash_including(:q => query), anything)
-      @api.fql_query(query)
-    end
-
-    it "passes on any other arguments provided" do
-      args = {:a => 2}
-      expect(@api).to receive(:get_object).with(anything, hash_including(args), anything)
-      @api.fql_query("a query", args)
-    end
-  end
-
-  describe "#fql_multiquery" do
-    it "makes a request to /fql" do
-      expect(@api).to receive(:get_object).with("fql", anything, anything)
-      @api.fql_multiquery 'query string'
-    end
-
-    it "passes a queries argument" do
-      queries = {foo: :x}
-
-      expect(@api).to receive(:get_object).with(anything, hash_including(:q => queries.to_json), anything)
-      @api.fql_multiquery(queries)
-    end
-
-    it "simplifies the response format" do
-      raw_results = [
-        {"name" => "query1", "fql_result_set" => [1, 2, 3]},
-        {"name" => "query2", "fql_result_set" => [:a, :b, :c]}
-      ]
-      expected_results = {
-        "query1" => [1, 2, 3],
-        "query2" => [:a, :b, :c]
-      }
-
-      allow(@api).to receive(:get_object).and_return(raw_results)
-      results = @api.fql_multiquery({:query => true})
-      expect(results).to eq(expected_results)
-    end
-
-    it "passes on any other arguments provided" do
-      args = {:a => 2}
-      expect(@api).to receive(:get_object).with(anything, hash_including(args), anything)
-      @api.fql_multiquery("a query", args)
-    end
-  end
 end
 
 
@@ -506,51 +451,6 @@ shared_examples_for "Koala GraphAPI with an access token" do
     end
   end
 
-  it "can access public information via FQL" do
-    result = @api.fql_query("select uid, first_name from user where uid = #{KoalaTest.user2_id}")
-    expect(result.size).to eq(1)
-    expect(result.first['first_name']).to eq(KoalaTest.user2_name)
-    expect(result.first['uid']).to eq(KoalaTest.user2_id.to_i)
-  end
-
-  it "can access public information via FQL.multiquery" do
-    result = @api.fql_multiquery(
-      :query1 => "select uid, first_name from user where uid = #{KoalaTest.user2_id}",
-      :query2 => "select uid, first_name from user where uid = #{KoalaTest.user1_id}"
-    )
-    expect(result.size).to eq(2)
-    # this should check for first_name, but there's an FB bug currently
-    expect(result["query1"].first['uid']).to eq(KoalaTest.user2_id.to_i)
-    # result["query1"].first['first_name'].should == KoalaTest.user2_name
-    expect(result["query2"].first['first_name']).to eq(KoalaTest.user1_name)
-  end
-
-  it "can access protected information via FQL" do
-    # Tests agains the permissions fql table
-
-    # get the current user's ID
-    # we're sneakily using the Graph API, which should be okay since it has its own tests
-    g = Koala::Facebook::API.new(@token)
-    id = g.get_object("me", :fields => "id")["id"]
-
-    # now send a query about your permissions
-    result = @api.fql_query("select read_stream from permissions where uid = #{id}")
-
-    expect(result.size).to eq(1)
-    # we've verified that you have read_stream permissions, so we can test against that
-    expect(result.first["read_stream"]).to eq(1)
-  end
-
-  it "can access protected information via FQL.multiquery" do
-    result = @api.fql_multiquery(
-      :query1 => "select post_id from stream where source_id = me()",
-      :query2 => "select fromid from comment where post_id in (select post_id from #query1)",
-      :query3 => "select uid, name from user where uid in (select fromid from #query2)"
-    )
-    expect(result.size).to eq(3)
-    expect(result.keys).to include("query1", "query2", "query3")
-  end
-
   # test all methods to make sure they pass data through to the API
   # we run the tests here (rather than in the common shared example group)
   # since some require access tokens
@@ -570,7 +470,6 @@ shared_examples_for "Koala GraphAPI with an access token" do
       :search => 3,
       :set_app_restrictions => 4,
       :get_page_access_token => 3,
-      :fql_query => 3, :fql_multiquery => 3,
       # methods that have special arguments
       :get_comments_for_urls => [["url1", "url2"], {}],
       :put_picture => ["x.jpg", "image/jpg", {}, "me"],
@@ -688,38 +587,5 @@ shared_examples_for "Koala GraphAPI without an access token" do
 
   it "can't delete a like" do
     expect { @api.delete_like("7204941866_119776748033392") }.to raise_error(Koala::Facebook::AuthenticationError)
-  end
-
-  # FQL_QUERY
-  describe "when making a FQL request" do
-    it "can access public information via FQL" do
-      result = @api.fql_query("select uid, first_name from user where uid = #{KoalaTest.user2_id}")
-      expect(result.size).to eq(1)
-      expect(result.first['first_name']).to eq(KoalaTest.user2_name)
-    end
-
-    it "can access public information via FQL.multiquery" do
-      result = @api.fql_multiquery(
-        :query1 => "select uid, first_name from user where uid = #{KoalaTest.user2_id}",
-        :query2 => "select uid, first_name from user where uid = #{KoalaTest.user1_id}"
-      )
-      expect(result.size).to eq(2)
-      expect(result["query1"].first['first_name']).to eq(KoalaTest.user2_name)
-      expect(result["query2"].first['first_name']).to eq(KoalaTest.user1_name)
-    end
-
-    it "can't access protected information via FQL" do
-      expect { @api.fql_query("select read_stream from permissions where uid = #{KoalaTest.user2_id}") }.to raise_error(Koala::Facebook::APIError)
-    end
-
-    it "can't access protected information via FQL.multiquery" do
-      expect {
-        @api.fql_multiquery(
-          :query1 => "select post_id from stream where source_id = me()",
-          :query2 => "select fromid from comment where post_id in (select post_id from #query1)",
-          :query3 => "select uid, name from user where uid in (select fromid from #query2)"
-        )
-      }.to raise_error(Koala::Facebook::APIError)
-    end
   end
 end

--- a/spec/support/koala_test.rb
+++ b/spec/support/koala_test.rb
@@ -157,12 +157,12 @@ module KoalaTest
     print "Validating permissions for live testing..."
     # make sure we have the necessary permissions
     api = Koala::Facebook::API.new(token)
-    perms = api.fql_query("select #{testing_permissions} from permissions where uid = me()")[0]
-    perms.each_pair do |perm, value|
-      if value == (perm == "read_insights" ? 1 : 0) # live testing depends on insights calls failing
-        puts "failed!\n" # put a new line after the print above
-        raise ArgumentError, "Your access token must have #{testing_permissions.join(", ")}, and lack read_insights.  You have: #{perms.inspect}"
-      end
+    perms = api.get_connect("me", "permissions")["data"]
+
+    # live testing depends on insights calls failing
+    if perms.keys.include?("read_insights") || (perms.keys & testing_permissions) != testing_permissions
+      puts "failed!\n" # put a new line after the print above
+      raise ArgumentError, "Your access token must have #{testing_permissions.join(", ")}, and lack read_insights.  You have: #{perms.inspect}"
     end
     puts "done!"
   end


### PR DESCRIPTION
Facebook removed support for FQL on August 8, 2016, so we can remove support for it from Koala.