### PR TITLE
Remove legacy high-level constants

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Internal improvements:
 * Completely rewrote HTTPService#make_request and several others, extracting most logic into
   HTTPService::Request (#566)
 * Use the more secure JSON.parse instead of JSON.load (thanks, lautis!) (#567)
+* Removed legacy high-level constants (#569)
 
 Testing improvements:
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,17 +1,24 @@
 v3.0.0
 ======
 
+Key breaking changes:
+
+* HTTPService.make_request now requires an HTTPService::Request object (Koala.make_request does
+  not)
+* HTTPService behavior *should not* change, but in edge cases might. (If so, please let me know.)
+* Empty response bodies in batch API calls will raise a JSON parse error rather than returning nil
+
 Removed features:
 
-* Removed the old Rest API, since Facebook doesn't support it (#568)
+* Removed support for the Rest API, since Facebook removed support for it (#568)
 * Removed support for FQL, which Facebook removed on August 8, 2016 (#569)
+* Removed legacy duplication of serveral constants in the Koala module (#569)
 
 Internal improvements:
 
-* Completely rewrote HTTPService#make_request and several others, extracting most logic into
+* Completely rewrote HTTPService.make_request and several others, extracting most logic into
   HTTPService::Request (#566)
 * Use the more secure JSON.parse instead of JSON.load (thanks, lautis!) (#567)
-* Removed legacy high-level constants (#569)
 
 Testing improvements:
 

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -1,5 +1,6 @@
 # graph_batch_api and legacy are required at the bottom, since they depend on API being defined
 require 'koala/api/graph_api'
+require 'koala/api/graph_collection'
 require 'openssl'
 
 module Koala

--- a/lib/koala/api/batch_operation.rb
+++ b/lib/koala/api/batch_operation.rb
@@ -1,4 +1,5 @@
 require 'koala/api'
+require 'koala/api/graph_batch_api'
 
 module Koala
   module Facebook
@@ -65,13 +66,13 @@ module Koala
         def process_binary_args
           # collect binary files
           @args.each_pair do |key, value|
-            if UploadableIO.binary_content?(value)
+            if HTTPService::UploadableIO.binary_content?(value)
               @files ||= {}
               # we use a class-level counter to ensure unique file identifiers across multiple batch operations
               # (this is thread safe, since we just care about uniqueness)
               # so remove the file from the original hash and add it to the file store
               id = "op#{identifier}_file#{@files.keys.length}"
-              @files[id] = @args.delete(key).is_a?(UploadableIO) ? value : UploadableIO.new(value)
+              @files[id] = @args.delete(key).is_a?(HTTPService::UploadableIO) ? value : HTTPService::UploadableIO.new(value)
             end
           end
         end

--- a/lib/koala/api/batch_operation.rb
+++ b/lib/koala/api/batch_operation.rb
@@ -81,9 +81,5 @@ module Koala
         end
       end
     end
-
-    # @private
-    # legacy support for when BatchOperation lived directly under Koala::Facebook
-    BatchOperation = GraphBatchAPI::BatchOperation
   end
 end

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -424,13 +424,13 @@ module Koala
       # Those methods use get_page to request another set of results from Facebook.
       #
       # @note You'll rarely need to use this method unless you're using Sinatra or another non-Rails framework
-      #       (see {Koala::Facebook::GraphCollection GraphCollection} for more information).
+      #       (see {Koala::Facebook::API::GraphCollection GraphCollection} for more information).
       #
       # @param params an array of arguments to graph_call
-      #               as returned by {Koala::Facebook::GraphCollection.parse_page_url}.
+      #               as returned by {Koala::Facebook::API::GraphCollection.parse_page_url}.
       # @param block (see Koala::Facebook::API#api)
       #
-      # @return Koala::Facebook::GraphCollection the appropriate page of results (an empty array if there are none)
+      # @return Koala::Facebook::API::GraphCollection the appropriate page of results (an empty array if there are none)
       def get_page(params, &block)
         graph_call(*params, &block)
       end
@@ -505,7 +505,7 @@ module Koala
         end
 
         # turn this into a GraphCollection if it's pageable
-        result = GraphCollection.evaluate(result, self)
+        result = API::GraphCollection.evaluate(result, self)
 
         # now process as appropriate for the given call (get picture header, etc.)
         post_processing ? post_processing.call(result) : result
@@ -534,7 +534,7 @@ module Koala
           fb_expected_arg_name = method == "photos" ? :url : :file_url
           args.merge!(fb_expected_arg_name => media_args.first)
         else
-          args["source"] = Koala::UploadableIO.new(*media_args.slice(0, 1 + args_offset))
+          args["source"] = Koala::HTTPService::UploadableIO.new(*media_args.slice(0, 1 + args_offset))
         end
 
         [target_id, method, args, options]

--- a/lib/koala/api/graph_collection.rb
+++ b/lib/koala/api/graph_collection.rb
@@ -113,9 +113,5 @@ module Koala
         end
       end
     end
-
-    # @private
-    # legacy support for when GraphCollection lived directly under Koala::Facebook
-    GraphCollection = API::GraphCollection
   end
 end

--- a/lib/koala/api/graph_collection.rb
+++ b/lib/koala/api/graph_collection.rb
@@ -23,7 +23,7 @@ module Koala
         # @param api the Graph {Koala::Facebook::API API} instance to use to make calls
         #            (usually the API that made the original call).
         #
-        # @return [Koala::Facebook::GraphCollection] an initialized GraphCollection
+        # @return [Koala::Facebook::API::GraphCollection] an initialized GraphCollection
         #         whose paging, summary, raw_response, and api attributes are populated.
         def initialize(response, api)
           super response["data"]

--- a/lib/koala/http_service/multipart_request.rb
+++ b/lib/koala/http_service/multipart_request.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 
-module Koala  
+module Koala
   module HTTPService
     class MultipartRequest < Faraday::Request::Multipart
       # Facebook expects nested parameters to be passed in a certain way
@@ -8,15 +8,15 @@ module Koala
       # Faraday needs two changes to make that work:
       # 1) [] need to be escaped (e.g. params[foo]=bar ==> params%5Bfoo%5D=bar)
       # 2) such messages need to be multipart-encoded
-    
+
       self.mime_type = 'multipart/form-data'.freeze
-    
+
       def process_request?(env)
         # if the request values contain any hashes or arrays, multipart it
         super || !!(env[:body].respond_to?(:values) && env[:body].values.find {|v| v.is_a?(Hash) || v.is_a?(Array)})
-      end   
-    
-    
+      end
+
+
       def process_params(params, prefix = nil, pieces = nil, &block)
         params.inject(pieces || []) do |all, (key, value)|
           key = "#{prefix}%5B#{key}%5D" if prefix
@@ -34,8 +34,4 @@ module Koala
       end
     end
   end
-  
-  # @private
-  # legacy support for when MultipartRequest lived directly under Koala
-  MultipartRequest = HTTPService::MultipartRequest  
 end

--- a/lib/koala/http_service/response.rb
+++ b/lib/koala/http_service/response.rb
@@ -11,8 +11,4 @@ module Koala
       end
     end
   end
-  
-  # @private
-  # legacy support for when Response lived directly under Koala
-  Response = HTTPService::Response
 end

--- a/lib/koala/http_service/uploadable_io.rb
+++ b/lib/koala/http_service/uploadable_io.rb
@@ -181,8 +181,4 @@ module Koala
       end
     end
   end
-
-  # @private
-  # legacy support for when UploadableIO lived directly under Koala
-  UploadableIO = HTTPService::UploadableIO
 end

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -58,11 +58,11 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           @batch_queue = []
           allow(Koala::Facebook::API).to receive(:batch_calls).and_return(@batch_queue)
 
-          allow(Koala::UploadableIO).to receive(:new).with(@binary).and_return(@uploadable_io)
-          allow(Koala::UploadableIO).to receive(:binary_content?).and_return(false)
-          allow(Koala::UploadableIO).to receive(:binary_content?).with(@binary).and_return(true)
-          allow(Koala::UploadableIO).to receive(:binary_content?).with(@uploadable_io).and_return(true)
-          allow(@uploadable_io).to receive(:is_a?).with(Koala::UploadableIO).and_return(true)
+          allow(Koala::HTTPService::UploadableIO).to receive(:new).with(@binary).and_return(@uploadable_io)
+          allow(Koala::HTTPService::UploadableIO).to receive(:binary_content?).and_return(false)
+          allow(Koala::HTTPService::UploadableIO).to receive(:binary_content?).with(@binary).and_return(true)
+          allow(Koala::HTTPService::UploadableIO).to receive(:binary_content?).with(@uploadable_io).and_return(true)
+          allow(@uploadable_io).to receive(:is_a?).with(Koala::HTTPService::UploadableIO).and_return(true)
 
           @args[:method] = "post" # files are always post
         end
@@ -243,11 +243,11 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
       describe "with binary files" do
         before :each do
           @binary = double("Binary file")
-          allow(Koala::UploadableIO).to receive(:binary_content?).and_return(false)
-          allow(Koala::UploadableIO).to receive(:binary_content?).with(@binary).and_return(true)
+          allow(Koala::HTTPService::UploadableIO).to receive(:binary_content?).and_return(false)
+          allow(Koala::HTTPService::UploadableIO).to receive(:binary_content?).with(@binary).and_return(true)
           @uploadable_io = double("UploadableIO")
-          allow(Koala::UploadableIO).to receive(:new).with(@binary).and_return(@uploadable_io)
-          allow(@uploadable_io).to receive(:is_a?).with(Koala::UploadableIO).and_return(true)
+          allow(Koala::HTTPService::UploadableIO).to receive(:new).with(@binary).and_return(@uploadable_io)
+          allow(@uploadable_io).to receive(:is_a?).with(Koala::HTTPService::UploadableIO).and_return(true)
 
           @batch_queue = []
           allow(Koala::Facebook::API).to receive(:batch_calls).and_return(@batch_queue)
@@ -486,7 +486,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_object('me')
         batch_api.get_connections('me', 'friends')
       end
-      expect(friends).to be_a(Koala::Facebook::GraphCollection)
+      expect(friends).to be_a(Koala::Facebook::API::GraphCollection)
     end
 
     it 'turns pageable results into GraphCollections' do
@@ -519,7 +519,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_connections(@app_id, 'insights', {}, {"access_token" => @app_api.access_token})
       end
       expect(me['id']).not_to be_nil
-      expect(insights).to be_an(Koala::Facebook::GraphCollection)
+      expect(insights).to be_an(Koala::Facebook::API::GraphCollection)
     end
 
     it "handles requests passing the access token option as a symbol instead of a string" do
@@ -528,7 +528,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
         batch_api.get_connections(@app_id, 'insights', {}, {:access_token => @app_api.access_token})
       end
       expect(me['id']).not_to be_nil
-      expect(insights).to be_an(Koala::Facebook::GraphCollection)
+      expect(insights).to be_an(Koala::Facebook::API::GraphCollection)
     end
 
     it "preserves batch-op specific access tokens in GraphCollection returned from batch" do

--- a/spec/cases/graph_collection_spec.rb
+++ b/spec/cases/graph_collection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Koala::Facebook::GraphCollection do
+describe Koala::Facebook::API::GraphCollection do
   let(:paging){ {:paging => true} }
 
   before(:each) do
@@ -10,15 +10,15 @@ describe Koala::Facebook::GraphCollection do
       "summary" => [3]
     }
     @api = Koala::Facebook::API.new("123")
-    @collection = Koala::Facebook::GraphCollection.new(@result, @api)
+    @collection = Koala::Facebook::API::GraphCollection.new(@result, @api)
   end
 
   it "subclasses Array" do
-    expect(Koala::Facebook::GraphCollection.ancestors).to include(Array)
+    expect(Koala::Facebook::API::GraphCollection.ancestors).to include(Array)
   end
 
   it "creates an array-like object" do
-    expect(Koala::Facebook::GraphCollection.new(@result, @api)).to be_an(Array)
+    expect(Koala::Facebook::API::GraphCollection.new(@result, @api)).to be_an(Array)
   end
 
   it "contains the result data" do
@@ -60,14 +60,14 @@ describe Koala::Facebook::GraphCollection do
     it "should return the previous page of results" do
       expect(@collection).to receive(:previous_page_params).and_return([@base, @args])
       expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(@second_page)
-      expect(Koala::Facebook::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
       expect(@collection.previous_page).to eq(@page_of_results)
     end
 
     it "should return the next page of results" do
       expect(@collection).to receive(:next_page_params).and_return([@base, @args])
       expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(@second_page)
-      expect(Koala::Facebook::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
 
       expect(@collection.next_page).to eq(@page_of_results)
     end
@@ -84,13 +84,13 @@ describe Koala::Facebook::GraphCollection do
     describe "#parse_page_url" do
       it "should pass the url to the class method" do
         url = double("url")
-        expect(Koala::Facebook::GraphCollection).to receive(:parse_page_url).with(url)
+        expect(Koala::Facebook::API::GraphCollection).to receive(:parse_page_url).with(url)
         @collection.parse_page_url(url)
       end
 
       it "should return the result of the class method" do
         parsed_content = double("parsed_content")
-        allow(Koala::Facebook::GraphCollection).to receive(:parse_page_url).and_return(parsed_content)
+        allow(Koala::Facebook::API::GraphCollection).to receive(:parse_page_url).and_return(parsed_content)
         expect(@collection.parse_page_url(double("url"))).to eq(parsed_content)
       end
     end
@@ -98,23 +98,23 @@ describe Koala::Facebook::GraphCollection do
     describe ".parse_page_url" do
       it "should return the base as the first array entry" do
         base = "url_path"
-        expect(Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/#{base}?anything").first).to eq(base)
+        expect(Koala::Facebook::API::GraphCollection.parse_page_url("http://facebook.com/#{base}?anything").first).to eq(base)
       end
 
       it "should return the arguments as a hash as the last array entry" do
         args_hash = {"one" => "val_one", "two" => "val_two"}
-        expect(Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/anything?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}").last).to eq(args_hash)
+        expect(Koala::Facebook::API::GraphCollection.parse_page_url("http://facebook.com/anything?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}").last).to eq(args_hash)
       end
 
       it "works with non-.com addresses" do
         base = "url_path"
         args_hash = {"one" => "val_one", "two" => "val_two"}
-        expect(Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/#{base}?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}")).to eq([base, args_hash])
+        expect(Koala::Facebook::API::GraphCollection.parse_page_url("http://facebook.com/#{base}?#{args_hash.map {|k,v| "#{k}=#{v}" }.join("&")}")).to eq([base, args_hash])
       end
 
       it "works with addresses with irregular characters" do
         access_token = "appid123a|fdcba"
-        base, args_hash = Koala::Facebook::GraphCollection.parse_page_url("http://facebook.com/foo?token=#{access_token}")
+        base, args_hash = Koala::Facebook::API::GraphCollection.parse_page_url("http://facebook.com/foo?token=#{access_token}")
         expect(args_hash["token"]).to eq(access_token)
       end
     end
@@ -123,29 +123,29 @@ describe Koala::Facebook::GraphCollection do
   describe ".evaluate" do
     it "returns the original result if it's provided a non-hash result" do
       result = []
-      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns the original result if it's provided a nil result" do
       result = nil
-      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns the original result if the result doesn't have a data key" do
       result = {"paging" => {}}
-      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns the original result if the result's data key isn't an array" do
       result = {"data" => {}, "paging" => {}}
-      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(result)
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
     it "returns a new GraphCollection of the result if it has an array data key and a paging key" do
       result = {"data" => [], "paging" => {}}
       expected = :foo
-      expect(Koala::Facebook::GraphCollection).to receive(:new).with(result, @api).and_return(expected)
-      expect(Koala::Facebook::GraphCollection.evaluate(result, @api)).to eq(expected)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(result, @api).and_return(expected)
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(expected)
     end
   end
 

--- a/spec/cases/http_service/request_spec.rb
+++ b/spec/cases/http_service/request_spec.rb
@@ -113,7 +113,7 @@ module Koala
         it "turns any UploadableIOs to UploadIOs" do
           # technically this is done for all requests, but you don't send GET requests with files
           upload_io = double("UploadIO")
-          u = Koala::UploadableIO.new("/path/to/stuff", "img/jpg")
+          u = Koala::HTTPService::UploadableIO.new("/path/to/stuff", "img/jpg")
           allow(u).to receive(:to_upload_io).and_return(upload_io)
           request = Request.new(path: path, verb: "post", args: {an_upload: u})
           expect(request.post_args[:an_upload]).to eq(upload_io)

--- a/spec/cases/uploadable_io_spec.rb
+++ b/spec/cases/uploadable_io_spec.rb
@@ -8,7 +8,7 @@ module Koala::MIME
   end
 end
 
-describe "Koala::UploadableIO" do
+describe "Koala::HTTPService::UploadableIO" do
   def rails_3_mocks
     tempfile = double('Tempfile', :path => "foo")
     uploaded_file = double('ActionDispatch::Http::UploadedFile',
@@ -39,15 +39,15 @@ describe "Koala::UploadableIO" do
         end
 
         it "returns an UploadIO with the same file path" do
-          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@path)
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@path)
         end
 
         it "returns an UploadIO with the same content type" do
-          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(@stub_type)
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).content_type).to eq(@stub_type)
         end
 
         it "returns an UploadIO with the file's name" do
-          expect(Koala::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@path))
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@path))
         end
       end
 
@@ -68,16 +68,16 @@ describe "Koala::UploadableIO" do
         end
 
         it "returns an UploadIO with the same io" do
-          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@koala_io_params[0])
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@koala_io_params[0])
         end
 
         it "returns an UploadableIO with the same content_type" do
           content_stub = @koala_io_params[1] = double('Content Type')
-          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
         end
 
         it "returns an UploadableIO with the right filename" do
-          expect(Koala::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@file.path))
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@file.path))
         end
       end
 
@@ -100,16 +100,16 @@ describe "Koala::UploadableIO" do
 
         it "returns an UploadIO with the same io" do
           #Problem comparing Tempfile in Ruby 1.8, REE and Rubinius mode 1.8
-          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path.path).to eq(@koala_io_params[0].path)
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).io_or_path.path).to eq(@koala_io_params[0].path)
         end
 
         it "returns an UploadableIO with the same content_type" do
           content_stub = @koala_io_params[1] = double('Content Type')
-          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
         end
 
         it "returns an UploadableIO with the right filename" do
-          expect(Koala::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@file.path))
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).filename).to eq(File.basename(@file.path))
         end
       end
 
@@ -130,18 +130,18 @@ describe "Koala::UploadableIO" do
         end
 
         it "returns an UploadableIO with the same io" do
-          expect(Koala::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@koala_io_params[0])
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).io_or_path).to eq(@koala_io_params[0])
         end
 
         it "returns an UploadableIO with the same content_type" do
           content_stub = @koala_io_params[1] = double('Content Type')
-          expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
+          expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).content_type).to eq(content_stub)
         end
       end
 
       describe "and no content type" do
         it "raises an exception" do
-          expect { Koala::UploadableIO.new(*@koala_io_params) }.to raise_exception(Koala::KoalaError)
+          expect { Koala::HTTPService::UploadableIO.new(*@koala_io_params) }.to raise_exception(Koala::KoalaError)
         end
       end
     end
@@ -154,17 +154,17 @@ describe "Koala::UploadableIO" do
       it "gets the path from the tempfile associated with the UploadedFile" do
         expected_path = double('Tempfile')
         expect(@tempfile).to receive(:path).and_return(expected_path)
-        expect(Koala::UploadableIO.new(@uploaded_file).io_or_path).to eq(expected_path)
+        expect(Koala::HTTPService::UploadableIO.new(@uploaded_file).io_or_path).to eq(expected_path)
       end
 
       it "gets the content type via the content_type method" do
         expected_content_type = double('Content Type')
         expect(@uploaded_file).to receive(:content_type).and_return(expected_content_type)
-        expect(Koala::UploadableIO.new(@uploaded_file).content_type).to eq(expected_content_type)
+        expect(Koala::HTTPService::UploadableIO.new(@uploaded_file).content_type).to eq(expected_content_type)
       end
 
       it "gets the filename from the UploadedFile" do
-        expect(Koala::UploadableIO.new(@uploaded_file).filename).to eq(@uploaded_file.original_filename)
+        expect(Koala::HTTPService::UploadableIO.new(@uploaded_file).filename).to eq(@uploaded_file.original_filename)
       end
     end
 
@@ -177,7 +177,7 @@ describe "Koala::UploadableIO" do
         expected_file = double('File')
         @file_hash[:tempfile] = expected_file
 
-        uploadable = Koala::UploadableIO.new(@file_hash)
+        uploadable = Koala::HTTPService::UploadableIO.new(@file_hash)
         expect(uploadable.io_or_path).to eq(expected_file)
       end
 
@@ -185,12 +185,12 @@ describe "Koala::UploadableIO" do
         expected_content_type = double('Content Type')
         @file_hash[:type] = expected_content_type
 
-        uploadable = Koala::UploadableIO.new(@file_hash)
+        uploadable = Koala::HTTPService::UploadableIO.new(@file_hash)
         expect(uploadable.content_type).to eq(expected_content_type)
       end
 
       it "gets the content type from the :type key" do
-        uploadable = Koala::UploadableIO.new(@file_hash)
+        uploadable = Koala::HTTPService::UploadableIO.new(@file_hash)
         expect(uploadable.filename).to eq(@file_hash[:filename])
       end
     end
@@ -199,12 +199,12 @@ describe "Koala::UploadableIO" do
       # what that means is tested below
       it "should accept a file object alone" do
         params = [BEACH_BALL_PATH]
-        expect { Koala::UploadableIO.new(*params) }.not_to raise_exception
+        expect { Koala::HTTPService::UploadableIO.new(*params) }.not_to raise_exception
       end
 
       it "should accept a file path alone" do
         params = [BEACH_BALL_PATH]
-        expect { Koala::UploadableIO.new(*params) }.not_to raise_exception
+        expect { Koala::HTTPService::UploadableIO.new(*params) }.not_to raise_exception
       end
     end
   end
@@ -218,7 +218,7 @@ describe "Koala::UploadableIO" do
     context "if no filename was provided" do
       it "should call the constructor with the content type, file name, and a dummy file name" do
         expect(UploadIO).to receive(:new).with(BEACH_BALL_PATH, "content/type", anything).and_return(@upload_io)
-        expect(Koala::UploadableIO.new(BEACH_BALL_PATH, "content/type").to_upload_io).to eq(@upload_io)
+        expect(Koala::HTTPService::UploadableIO.new(BEACH_BALL_PATH, "content/type").to_upload_io).to eq(@upload_io)
       end
     end
 
@@ -226,7 +226,7 @@ describe "Koala::UploadableIO" do
       it "should call the constructor with the content type, file name, and the filename" do
         filename = "file"
         expect(UploadIO).to receive(:new).with(BEACH_BALL_PATH, "content/type", filename).and_return(@upload_io)
-        Koala::UploadableIO.new(BEACH_BALL_PATH, "content/type", filename).to_upload_io
+        Koala::HTTPService::UploadableIO.new(BEACH_BALL_PATH, "content/type", filename).to_upload_io
       end
     end
   end
@@ -234,33 +234,33 @@ describe "Koala::UploadableIO" do
   describe "getting a file" do
     it "returns the File if initialized with a file" do
       f = File.new(BEACH_BALL_PATH)
-      expect(Koala::UploadableIO.new(f).to_file).to eq(f)
+      expect(Koala::HTTPService::UploadableIO.new(f).to_file).to eq(f)
     end
 
     it "should open up and return a file corresponding to the path if io_or_path is a path" do
       result = double("File")
       expect(File).to receive(:open).with(BEACH_BALL_PATH).and_return(result)
-      expect(Koala::UploadableIO.new(BEACH_BALL_PATH).to_file).to eq(result)
+      expect(Koala::HTTPService::UploadableIO.new(BEACH_BALL_PATH).to_file).to eq(result)
     end
   end
 
   describe ".binary_content?" do
     it "returns true for Rails 3 file uploads" do
-      expect(Koala::UploadableIO.binary_content?(rails_3_mocks.last)).to be_truthy
+      expect(Koala::HTTPService::UploadableIO.binary_content?(rails_3_mocks.last)).to be_truthy
     end
 
     it "returns true for Sinatra file uploads" do
-      expect(Koala::UploadableIO.binary_content?(rails_3_mocks.last)).to be_truthy
+      expect(Koala::HTTPService::UploadableIO.binary_content?(rails_3_mocks.last)).to be_truthy
     end
 
     it "returns true for File objects" do
-      expect(Koala::UploadableIO.binary_content?(File.open(BEACH_BALL_PATH))).to be_truthy
+      expect(Koala::HTTPService::UploadableIO.binary_content?(File.open(BEACH_BALL_PATH))).to be_truthy
     end
 
     it "returns false for everything else" do
-      expect(Koala::UploadableIO.binary_content?(StringIO.new)).to be_falsey
-      expect(Koala::UploadableIO.binary_content?(BEACH_BALL_PATH)).to be_falsey
-      expect(Koala::UploadableIO.binary_content?(nil)).to be_falsey
+      expect(Koala::HTTPService::UploadableIO.binary_content?(StringIO.new)).to be_falsey
+      expect(Koala::HTTPService::UploadableIO.binary_content?(BEACH_BALL_PATH)).to be_falsey
+      expect(Koala::HTTPService::UploadableIO.binary_content?(nil)).to be_falsey
     end
   end
 end  # describe UploadableIO

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -32,14 +32,14 @@ shared_examples_for "Koala GraphAPI" do
     it "passes the results through GraphCollection.evaluate" do
       result = {}
       allow(@api).to receive(:api).and_return(result)
-      expect(Koala::Facebook::GraphCollection).to receive(:evaluate).with(result, @api)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:evaluate).with(result, @api)
       @api.graph_call("/me")
     end
 
     it "returns the results of GraphCollection.evaluate" do
       expected = {}
       allow(@api).to receive(:api).and_return([])
-      expect(Koala::Facebook::GraphCollection).to receive(:evaluate).and_return(expected)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:evaluate).and_return(expected)
       expect(@api.graph_call("/me")).to eq(expected)
     end
 
@@ -313,7 +313,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
     it "sets options[:video] to true" do
       source = double("UploadIO")
-      allow(Koala::UploadableIO).to receive(:new).and_return(source)
+      allow(Koala::HTTPService::UploadableIO).to receive(:new).and_return(source)
       allow(source).to receive(:requires_base_http_service).and_return(false)
       expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(:video => true)).and_return(Koala::HTTPService::Response.new(200, "[]", {}))
       @api.put_video("foo")
@@ -506,7 +506,7 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
     # GraphCollection methods
     it "gets a GraphCollection when getting connections" do
       @result = @api.get_connections(KoalaTest.page, "photos")
-      expect(@result).to be_a(Koala::Facebook::GraphCollection)
+      expect(@result).to be_a(Koala::Facebook::API::GraphCollection)
     end
 
     it "returns nil if the get_collections call fails with nil" do
@@ -517,7 +517,7 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
 
     it "gets a GraphCollection when searching" do
       result = @api.search("facebook")
-      expect(result).to be_a(Koala::Facebook::GraphCollection)
+      expect(result).to be_a(Koala::Facebook::API::GraphCollection)
     end
 
     it "returns nil if the search call fails with nil" do
@@ -528,7 +528,7 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
 
     it "gets a GraphCollection when paging through results" do
       @results = @api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}])
-      expect(@results).to be_a(Koala::Facebook::GraphCollection)
+      expect(@results).to be_a(Koala::Facebook::API::GraphCollection)
     end
 
     it "returns nil if the page call fails with nil" do

--- a/spec/support/mock_http_service.rb
+++ b/spec/support/mock_http_service.rb
@@ -89,7 +89,7 @@ module Koala
         # ensure our args are all stringified
         value = if v.is_a?(String)
           should_json_decode?(v) ? JSON.parse(v) : v
-        elsif v.is_a?(Koala::UploadableIO)
+        elsif v.is_a?(Koala::HTTPService::UploadableIO)
           # obviously there are no files in the yaml
           "[FILE]"
         else

--- a/spec/support/uploadable_io_shared_examples.rb
+++ b/spec/support/uploadable_io_shared_examples.rb
@@ -12,7 +12,7 @@ shared_examples_for "MIME::Types can't return results" do
       else
         @koala_io_params[0] = path
       end
-      expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(mime_type)
+      expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).content_type).to eq(mime_type)
     end
 
     it "should get content types for #{extension} using basic analysis with file names with more than one dot" do
@@ -22,7 +22,7 @@ shared_examples_for "MIME::Types can't return results" do
       else
         @koala_io_params[0] = path
       end
-      expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(mime_type)
+      expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).content_type).to eq(mime_type)
     end
   end
 
@@ -37,7 +37,7 @@ shared_examples_for "MIME::Types can't return results" do
     end
 
     it "should throw an exception" do
-      expect { Koala::UploadableIO.new(*@koala_io_params) }.to raise_exception(Koala::KoalaError)
+      expect { Koala::HTTPService::UploadableIO.new(*@koala_io_params) }.to raise_exception(Koala::KoalaError)
     end
   end
 end
@@ -47,7 +47,7 @@ shared_examples_for "determining a mime type" do
     it "should return an UploadIO with MIME::Types-determined type if the type exists" do
       type_result = ["type"]
       allow(Koala::MIME::Types).to receive(:type_for).and_return(type_result)
-      expect(Koala::UploadableIO.new(*@koala_io_params).content_type).to eq(type_result.first)
+      expect(Koala::HTTPService::UploadableIO.new(*@koala_io_params).content_type).to eq(type_result.first)
     end
   end
 


### PR DESCRIPTION
Waaaaaay back in the day a bunch of constants lived directly under Koala. There's been legacy support for that for a while, but we don't need that anymore.