### PR TITLE
Remove hacky JSON hack

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ Internal improvements:
 * Completely rewrote HTTPService.make_request and several others, extracting most logic into
   HTTPService::Request (#566)
 * Use the more secure JSON.parse instead of JSON.load (thanks, lautis!) (#567)
+* Use JSON's quirks_mode option to remove hacky JSON hack (#573 -- thanks sakuro for the
+  suggestion!)
 
 Testing improvements:
 

--- a/koala.gemspec
+++ b/koala.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency("faraday")
   gem.add_runtime_dependency("addressable")
+  gem.add_runtime_dependency("json", ">= 2.0")
 end

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -82,10 +82,9 @@ module Koala
           component == :response ? result : result.send(options[:http_component])
         else
           # parse the body as JSON and run it through the error checker (if provided)
-          # Note: Facebook sometimes sends results like "true" and "false", which are valid[RFC7159]
-          # but unsupported by Ruby's stdlib[RFC4627] and cause JSON.parse to fail -- so we account for
-          # that by wrapping the result in []
-          JSON.parse("[#{result.body.to_s}]")[0]
+          # quirks_mode is needed because Facebook sometimes returns a raw true or false value --
+          # in Ruby 2.4 we can drop that.
+          JSON.parse(result.body.to_s, quirks_mode: true) unless result.body.empty?
         end
       end
 

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -74,8 +74,9 @@ module Koala
               if (error = check_response(call_result['code'], call_result['body'].to_s, parsed_headers))
                 raw_result = error
               else
-                # (see note in regular api method about JSON parsing)
-                body = JSON.parse("[#{call_result['body'].to_s}]")[0]
+                # quirks_mode is needed because Facebook sometimes returns a raw true or false value --
+                # in Ruby 2.4 we can drop that.
+                body = JSON.parse(call_result['body'].to_s, quirks_mode: true)
 
                 # Get the HTTP component they want
                 raw_result = case batch_op.http_options[:http_component]

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -124,13 +124,11 @@ describe "Koala::Facebook::API" do
   end
 
   it "returns the body of the request as JSON if no http_component is given" do
-    response = double('response', :body => 'body', :status => 200)
+    result = {"a" => 2}
+    response = double('response', :body => result.to_json, :status => 200)
     allow(Koala).to receive(:make_request).and_return(response)
 
-    json_body = double('JSON body')
-    allow(JSON).to receive(:parse).and_return([json_body])
-
-    expect(@service.api('anything')).to eq(json_body)
+    expect(@service.api('anything')).to eq(result)
   end
 
   it "executes an error checking block if provided" do


### PR DESCRIPTION
Way back in the day (in 2011, if not earlier), we had to work around Facebook returning raw `true` and `false` values as the entirety of JSON responses, which Ruby's implementation of JSON did not handle well. The hack involved wrapping all values in an array and then taking the first value of it (e.g. `false` => `[false].first`).

These are valid results per the [JSON RFC](https://tools.ietf.org/html/rfc7159#page-13) and we shouldn't have to do that anymore. With Ruby 2.4 we won't have to at all, but for now we can use the `quirks_mode` option to parse those values properly.