### PR TITLE
Require object type when searching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ v3.0.0
 * HTTPService.make_request now requires an HTTPService::Request object (Koala.make_request does not, so most users shouldn't see a change)
 * Empty response bodies in batch API calls will raise a JSON::ParserError rather than returning nil
 * HTTPService behavior *should not* change, but in edge cases might. (If so, please let me know.)
+* API#search now requires a "type"/:type argument, matching Facebook's behavior (improving their
+  cryptic error message)
 
 Updated features:
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,14 +3,15 @@ v3.0.0
 
 **Key breaking changes:**
 
-* HTTPService.make_request now requires an HTTPService::Request object (Koala.make_request does
-  not)
-* HTTPService behavior *should not* change, but in edge cases might. (If so, please let me know.)
+* API#search now takes both term and type, since both are required: `api.search("facebook", "page")` vs `api.search("page", type: "page")`
+* HTTPService.make_request now requires an HTTPService::Request object (Koala.make_request does not, so most users shouldn't see a change)
 * Empty response bodies in batch API calls will raise a JSON::ParserError rather than returning nil
+* HTTPService behavior *should not* change, but in edge cases might. (If so, please let me know.)
 
 Updated features:
 
 * TestUser#befriend will provide the appsecret_proof if a secret is set (thanks, kwasimensah!)
+* API#search now requires an object type argument, matching Facebook's API (#575)
 
 Removed features:
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,6 @@ v3.0.0
 
 **Key breaking changes:**
 
-* API#search now takes both term and type, since both are required: `api.search("facebook", "page")` vs `api.search("page", type: "page")`
 * HTTPService.make_request now requires an HTTPService::Request object (Koala.make_request does not, so most users shouldn't see a change)
 * Empty response bodies in batch API calls will raise a JSON::ParserError rather than returning nil
 * HTTPService behavior *should not* change, but in edge cases might. (If so, please let me know.)
@@ -11,7 +10,7 @@ v3.0.0
 Updated features:
 
 * TestUser#befriend will provide the appsecret_proof if a secret is set (thanks, kwasimensah!)
-* API#search now requires an object type argument, matching Facebook's API (#575)
+* API#search now requires an object type parameter to be included, matching Facebook's API (#575)
 
 Removed features:
 

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -344,14 +344,14 @@ module Koala
       # See {http://developers.facebook.com/docs/reference/api/#searching Facebook documentation} for more information.
       #
       # @param search_terms the query to search for
+      # @param type the type of Facebook object to search
       # @param args additional arguments, such as type, fields, etc.
       # @param options (see #get_object)
       # @param block (see Koala::Facebook::API#api)
       #
       # @return [Koala::Facebook::API::GraphCollection] an array of search results
-      def search(search_terms, args = {}, options = {}, &block)
-        args.merge!({:q => search_terms}) unless search_terms.nil?
-        graph_call("search", args, "get", options, &block)
+      def search(search_terms, type, args = {}, options = {}, &block)
+        graph_call("search", args.merge("q" => search_terms, "type" => type), "get", options, &block)
       end
 
       # Convenience Methods

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -344,14 +344,16 @@ module Koala
       # See {http://developers.facebook.com/docs/reference/api/#searching Facebook documentation} for more information.
       #
       # @param search_terms the query to search for
-      # @param type the type of Facebook object to search
-      # @param args additional arguments, such as type, fields, etc.
+      # @param args object type and any additional arguments, such as fields, etc.
       # @param options (see #get_object)
       # @param block (see Koala::Facebook::API#api)
       #
       # @return [Koala::Facebook::API::GraphCollection] an array of search results
-      def search(search_terms, type, args = {}, options = {}, &block)
-        graph_call("search", args.merge("q" => search_terms, "type" => type), "get", options, &block)
+      def search(search_terms, args = {}, options = {}, &block)
+        # Normally we wouldn't enforce Facebook API behavior, but the API fails with cryptic error
+        # messages if you fail to include a type term. For a convenience method, that is valuable.
+        raise ArgumentError, "type must be includedin args when searching" unless args[:type] || args["type"]
+        graph_call("search", args.merge("q" => search_terms), "get", options, &block)
       end
 
       # Convenience Methods

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -189,9 +189,10 @@ describe "Koala::Facebook::API" do
       @api = Koala::Facebook::API.new
     end
 
+    # In theory this should behave the same with a GraphCollection, but those tests currently hit
+    # an endpoint that now requires a token.
     it_should_behave_like "Koala GraphAPI"
     it_should_behave_like "Koala GraphAPI without an access token"
-    it_should_behave_like "Koala GraphAPI with GraphCollection"
   end
 
   context '#api' do

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -268,15 +268,12 @@ graph_api:
         body: '{"error": {"type": "Exception","message": "No node specified"}}'
 
   /search:
-    q=facebook:
+    q=facebook&type=page:
       get:
         with_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
-        no_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
-    "limit=25&q=facebook&until=<%= TEST_DATA['search_time'] %>":
+    "limit=25&q=facebook&type=page&until=<%= TEST_DATA['search_time'] %>":
       get:
         with_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
-        no_token: '{"data": [{"id": "507731521_100412693339488"}], "paging": {"previous": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000", "next": "https:\/\/graph.facebook.com\/7204941866\/photos?limit=25&until=2008-09-15T18%3A30%3A25%2B0000"}}'
-
 
   '/115349521819193_113815981982767':
     no_args:

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -51,12 +51,6 @@ shared_examples_for "Koala GraphAPI" do
     end
   end
 
-  # SEARCH
-  it "can search" do
-    result = @api.search("facebook")
-    expect(result.length).to be_an(Integer)
-  end
-
   # DATA
   # access public info
 
@@ -138,12 +132,6 @@ shared_examples_for "Koala GraphAPI" do
     expect(result["http://developers.facebook.com/blog/post/490"] && result["http://developers.facebook.com/blog/post/472"]).to be_truthy
   end
 
-  # SEARCH
-  it "can search" do
-    result = @api.search("facebook")
-    expect(result.length).to be_an(Integer)
-  end
-
   # PAGING THROUGH COLLECTIONS
   # see also graph_collection_tests
   it "makes a request for a page when provided a specific set of page params" do
@@ -188,6 +176,12 @@ shared_examples_for "Koala GraphAPI with an access token" do
   it "can access connections from users" do
     result = @api.get_connections(KoalaTest.user2, "friends")
     expect(result.length).to be > 0
+  end
+
+  # SEARCH
+  it "can search" do
+    result = @api.search("facebook", "page")
+    expect(result.length).to be_an(Integer)
   end
 
   # PUT
@@ -467,7 +461,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
       :put_wall_post => 4,
       :put_comment => 3,
       :put_like => 2, :delete_like => 2,
-      :search => 3,
+      :search => 4,
       :set_app_restrictions => 4,
       :get_page_access_token => 3,
       # methods that have special arguments
@@ -516,18 +510,18 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
     end
 
     it "gets a GraphCollection when searching" do
-      result = @api.search("facebook")
+      result = @api.search("facebook", "page")
       expect(result).to be_a(Koala::Facebook::API::GraphCollection)
     end
 
     it "returns nil if the search call fails with nil" do
       # this happens sometimes
       expect(@api).to receive(:graph_call).and_return(nil)
-      expect(@api.search("facebook")).to be_nil
+      expect(@api.search("facebook", "page")).to be_nil
     end
 
     it "gets a GraphCollection when paging through results" do
-      @results = @api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}])
+      @results = @api.get_page(["search", {"q"=>"facebook", "type" => "page", "limit"=>"25", "until"=> KoalaTest.search_time}])
       expect(@results).to be_a(Koala::Facebook::API::GraphCollection)
     end
 

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -180,7 +180,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
 
   # SEARCH
   it "can search" do
-    result = @api.search("facebook", "page")
+    result = @api.search("facebook", type: "page")
     expect(result.length).to be_an(Integer)
   end
 
@@ -461,14 +461,14 @@ shared_examples_for "Koala GraphAPI with an access token" do
       :put_wall_post => 4,
       :put_comment => 3,
       :put_like => 2, :delete_like => 2,
-      :search => 4,
       :set_app_restrictions => 4,
       :get_page_access_token => 3,
       # methods that have special arguments
       :get_comments_for_urls => [["url1", "url2"], {}],
       :put_picture => ["x.jpg", "image/jpg", {}, "me"],
       :put_video => ["x.mp4", "video/mpeg4", {}, "me"],
-      :get_objects => [["x"], {}]
+      :get_objects => [["x"], {}],
+      :search => ["facebook", {"type" => "page"}]
     }.each_pair do |method_name, params|
       it "passes http options through for #{method_name}" do
         options = {:a => 2}
@@ -510,14 +510,14 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
     end
 
     it "gets a GraphCollection when searching" do
-      result = @api.search("facebook", "page")
+      result = @api.search("facebook", type: "page")
       expect(result).to be_a(Koala::Facebook::API::GraphCollection)
     end
 
     it "returns nil if the search call fails with nil" do
       # this happens sometimes
       expect(@api).to receive(:graph_call).and_return(nil)
-      expect(@api.search("facebook", "page")).to be_nil
+      expect(@api.search("facebook", type: "page")).to be_nil
     end
 
     it "gets a GraphCollection when paging through results" do
@@ -528,7 +528,7 @@ shared_examples_for "Koala GraphAPI with GraphCollection" do
     it "returns nil if the page call fails with nil" do
       # this happens sometimes
       expect(@api).to receive(:graph_call).and_return(nil)
-      expect(@api.get_page(["search", {"q"=>"facebook", "limit"=>"25", "until"=> KoalaTest.search_time}])).to be_nil
+      expect(@api.get_page(["search", {"q"=>"facebook", "type" => "page", "limit"=>"25", "until"=> KoalaTest.search_time}])).to be_nil
     end
   end
 end

--- a/spec/support/mock_http_service.rb
+++ b/spec/support/mock_http_service.rb
@@ -45,12 +45,12 @@ module Koala
         # to place a mock as well as a URL to request from
         # Facebook's servers for the actual data
         # (Don't forget to replace ACCESS_TOKEN with a real access token)
-        data_trace = [path, args, verb, options] * ': '
+        data_trace = [request.raw_path, request.raw_args, request.raw_verb, request.raw_options] * ': '
 
-        args = args == 'no_args' ? '' : "#{args}&"
+        args = request.raw_args == 'no_args' ? '' : "#{request.raw_args}&"
         args += 'format=json'
 
-        raise "Missing a mock response for #{data_trace}\nAPI PATH: #{[path, args].join('?')}"
+        raise "Missing a mock response for #{data_trace}\nAPI PATH: #{[request.path, request.raw_args].join('?')}"
       end
 
       response_object


### PR DESCRIPTION
Facebook used to allow searching on every type of object; nowadays, though, they require users to specify a type.

In general, Koala attempts not to track the behavior of the Facebook API. That said, the gem does have a number of convenience methods for not-entirely-straightforward APIs. Search is one of them (though it's only mildly-unintuitive); as such, it's a problem that its behavior doesn't match Facebook's (especially since Facebook throws cryptic error messages if the `type` argument isn't provided).

This PR requires the search term in the arguments array. The initial implementation added a second required parameter; since it's going in 3.0 that would be acceptable, but it's not worth adding a breaking change when there's a more descriptive non-breaking change:

```ruby
api.search("facebook", "page")
api.search("facebook", type: "page")
```