### PR TITLE
Remove dead get_comments_for_urls method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Removed features:
 * Removed support for the Rest API, since Facebook removed support for it (#568)
 * Removed support for FQL, which Facebook removed on August 8, 2016 (#569)
 * Removed legacy duplication of serveral constants in the Koala module (#569)
+* Removed API#get_comments_for_urls, which pointed to a no-longer-extant endpoint(#570)
 
 Internal improvements:
 
@@ -32,7 +33,7 @@ Internal improvements:
 
 Testing improvements:
 
-* Fixed a bunch of failing specs
+* Fixed a bunch of failing mocked specs
 
 v2.5.0
 ======

--- a/lib/koala/api/graph_api.rb
+++ b/lib/koala/api/graph_api.rb
@@ -393,21 +393,6 @@ module Koala
         block ? block.call(access_token_info) : access_token_info
       end
 
-      # Fetches the comments from fb:comments widgets for a given set of URLs (array or comma-separated string).
-      # See https://developers.facebook.com/blog/post/490.
-      #
-      # @param urls the URLs for which you want comments
-      # @param args (see #get_object)
-      # @param options (see #get_object)
-      # @param block (see Koala::Facebook::API#api)
-      #
-      # @returns a hash of urls => comment arrays
-      def get_comments_for_urls(urls = [], args = {}, options = {}, &block)
-        return [] if urls.empty?
-        args.merge!(:ids => urls.respond_to?(:join) ? urls.join(",") : urls)
-        get_object("comments", args, options, &block)
-      end
-
       # App restrictions require you to JSON-encode the restriction value. This
       # is neither obvious nor intuitive, so this convenience method is
       # provided.

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -122,16 +122,6 @@ shared_examples_for "Koala GraphAPI" do
     expect(result).to be_a(Array)
   end
 
-  it "can access comments for a URL" do
-    result = @api.get_comments_for_urls(["http://developers.facebook.com/blog/post/472"])
-    expect(result["http://developers.facebook.com/blog/post/472"]).to be_truthy
-  end
-
-  it "can access comments for 2 URLs" do
-    result = @api.get_comments_for_urls(["http://developers.facebook.com/blog/post/490", "http://developers.facebook.com/blog/post/472"])
-    expect(result["http://developers.facebook.com/blog/post/490"] && result["http://developers.facebook.com/blog/post/472"]).to be_truthy
-  end
-
   # PAGING THROUGH COLLECTIONS
   # see also graph_collection_tests
   it "makes a request for a page when provided a specific set of page params" do
@@ -462,7 +452,6 @@ shared_examples_for "Koala GraphAPI with an access token" do
       :search,
       :set_app_restrictions,
       :get_page_access_token,
-      :get_comments_for_urls,
       :get_objects
     ].each do |method_name|
       it "passes http options through for #{method_name}" do


### PR DESCRIPTION
The `get_comments_for_urls` method was a convenience method to [get comments for a Comment Box on a site](https://developers.facebook.com/blog/post/490). There are still comment boxes, but the associated API seems to have been removed at some point; `/comments` is not an endpoint listed in the [Graph API reference](https://developers.facebook.com/docs/graph-api/reference). (It's posible it's been folded into the [object/comments edge](https://developers.facebook.com/docs/graph-api/reference/v2.8/object/comments/), but I'm not sure.)

Given that this PR removes the convenience method.