### PR TITLE
Batch API no longer inherits from API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ v3.0.0
 **Key breaking changes:**
 
 * Koala now requires Ruby 2.1+ (or equivalent for JRuby, etc.)
+* GraphBatchAPI no longer inherits from API (the interface is otherwise unchanged)
 * Empty response bodies in batch API calls will raise a JSON::ParserError rather than returning nil
 * HTTPService.make_request now requires an HTTPService::Request object (Koala.make_request does
   not)

--- a/lib/koala/api/graph_api_methods.rb
+++ b/lib/koala/api/graph_api_methods.rb
@@ -32,7 +32,6 @@ module Koala
     # for the active user from the cookie provided by Facebook.
     # See the Koala and Facebook documentation for more information.
     module GraphAPIMethods
-
       # Objects
 
       # Get information about a Facebook object.
@@ -107,7 +106,7 @@ module Koala
       # @return true if successful, false (or an APIError) if not
       def delete_object(id, options = {}, &block)
         # Deletes the object with the given ID from the graph.
-        raise AuthenticationError.new(nil, nil, "Delete requires an access token") unless @access_token
+        raise AuthenticationError.new(nil, nil, "Delete requires an access token") unless access_token
         graph_call(id, {}, "delete", options, &block)
       end
 
@@ -157,7 +156,7 @@ module Koala
       # @return a hash containing the new object's id
       def put_connections(id, connection_name, args = {}, options = {}, &block)
         # Posts a certain connection
-        raise AuthenticationError.new(nil, nil, "Write operations require an access token") unless @access_token
+        raise AuthenticationError.new(nil, nil, "Write operations require an access token") unless access_token
 
         graph_call("#{id}/#{connection_name}", args, "post", options, &block)
       end
@@ -175,7 +174,7 @@ module Koala
       # @return (see #delete_object)
       def delete_connections(id, connection_name, args = {}, options = {}, &block)
         # Deletes a given connection
-        raise AuthenticationError.new(nil, nil, "Delete requires an access token") unless @access_token
+        raise AuthenticationError.new(nil, nil, "Delete requires an access token") unless access_token
         graph_call("#{id}/#{connection_name}", args, "delete", options, &block)
       end
 
@@ -336,7 +335,7 @@ module Koala
       # @return (see #delete_object)
       def delete_like(id, options = {}, &block)
         # Unlikes a given object for the logged-in user
-        raise AuthenticationError.new(nil, nil, "Unliking requires an access token") unless @access_token
+        raise AuthenticationError.new(nil, nil, "Unliking requires an access token") unless access_token
         graph_call("#{id}/likes", {}, "delete", options, &block)
       end
 
@@ -466,43 +465,7 @@ module Koala
         end
       end
 
-      # Make a call directly to the Graph API.
-      # (See any of the other methods for example invocations.)
-      #
-      # @param path the Graph API path to query (no leading / needed)
-      # @param args (see #get_object)
-      # @param verb the type of HTTP request to make (get, post, delete, etc.)
-      # @options (see #get_object)
-      #
-      # @yield response when making a batch API call, you can pass in a block
-      #        that parses the results, allowing for cleaner code.
-      #        The block's return value is returned in the batch results.
-      #        See the code for {#get_picture} for examples.
-      #        (Not needed in regular calls; you'll probably rarely use this.)
-      #
-      # @raise [Koala::Facebook::APIError] if Facebook returns an error
-      #
-      # @return the result from Facebook
-      def graph_call(path, args = {}, verb = "get", options = {}, &post_processing)
-        # enable appsecret_proof by default
-        options = {:appsecret_proof => true}.merge(options) if @app_secret
-        result = api(path, args, verb, options) do |response|
-          error = check_response(response.status, response.body, response.headers)
-          raise error if error
-        end
-
-        # turn this into a GraphCollection if it's pageable
-        result = API::GraphCollection.evaluate(result, self)
-
-        # now process as appropriate for the given call (get picture header, etc.)
-        post_processing ? post_processing.call(result) : result
-      end
-
       private
-
-      def check_response(http_status, body, headers)
-        GraphErrorChecker.new(http_status, body, headers).error_if_appropriate
-      end
 
       def parse_media_args(media_args, method)
         # photo and video uploads can accept different types of arguments (see above)

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -24,7 +24,7 @@ graph_api:
   # Common mock item responses
   item_deleted: &item_deleted
     delete:
-      with_token: 'true'
+      with_token: '{"success": true}'
 
   # OAuth error response
   oauth_error: &oauth_error
@@ -78,7 +78,7 @@ graph_api:
         with_token: '[{"code": 400, "body": "{\"error\":{\"type\":\"AnError\", \"message\":\"An error occurred!.\"}}"},{"code": 200, "body":"{\"id\":\"123\"}"}]'
     batch=<%= JSON.dump([{"method"=>"post", "relative_url"=>"FEED_ITEM_BATCH/likes"}, {"method"=>"delete", "relative_url"=> "FEED_ITEM_BATCH"}]) %>:
       post:
-        with_token: '[{"code": 200, "body": "{\"id\": \"MOCK_LIKE\"}"},{"code": 200, "body":true}]'
+        with_token: '[{"code": 200, "body": "{\"id\": \"MOCK_LIKE\"}"},{"code": 200, "body":"{\"success\":true}"}]'
 
     # dependencies
     batch=<%= JSON.dump([{"method"=>"get", "relative_url"=>"me", "name" => "getme"}, {"method"=>"get", "relative_url"=>"koppel", "depends_on" => "getme"}]) %>:

--- a/spec/support/graph_api_shared_examples.rb
+++ b/spec/support/graph_api_shared_examples.rb
@@ -186,7 +186,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
     result = @api.put_wall_post("Hello, world, from the test suite delete method!")
     object_id_to_delete = result["id"]
     delete_result = @api.delete_object(object_id_to_delete)
-    expect(delete_result).to eq(true)
+    expect(delete_result).to eq("success" => true)
   end
 
   it "can delete likes" do
@@ -194,7 +194,7 @@ shared_examples_for "Koala GraphAPI with an access token" do
     @temporary_object_id = result["id"]
     @api.put_like(@temporary_object_id)
     delete_like_result = @api.delete_like(@temporary_object_id)
-    expect(delete_like_result).to eq(true)
+    expect(delete_like_result).to eq("success" => true)
   end
 
   # additional put tests


### PR DESCRIPTION
When I and others first wrote the GraphBatchAPI, I had it inherit from API. As with all inheritance, this resulted in the two classes being entangled with each other; changes to the private implementation logic in one impacted the other, making it harder to refactor for 3.0.

As it turns out, GraphBatchAPI doesn't actually *need* to depend on the original API. A few simple changes (moving `graph_call` to API so that GraphAPIMethods just contain convenience methods) allow us to dramatically simplify the batch API implementation and make this a compositional relationship rather than an inheritance-based one.

This PR also merges in #551 (addressing the merge conflicts).