### PR TITLE
Exposes headers in each response

### DIFF
--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -55,7 +55,7 @@ module Koala
           http_component == :response ? response : response.send(http_component)
         else
           # turn this into a GraphCollection if it's pageable
-          API::GraphCollection.evaluate(response.data, self)
+          API::GraphCollection.evaluate(response, self)
         end
 
         # now process as appropriate for the given call (get picture header, etc.)

--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -62,10 +62,7 @@ module Koala
           post_process = batch_op.post_processing
 
           # turn any results that are pageable into GraphCollections
-          result = GraphCollection.evaluate(
-            result_from_response(call_result, batch_op),
-            original_api
-          )
+          result = result_from_response(call_result, batch_op)
 
           # and pass to post-processing callback if given
           if post_process
@@ -129,13 +126,15 @@ module Koala
         response  = options.fetch(:response)
         headers   = options.fetch(:headers)
 
+        result = Koala::HTTPService::Response.new(response['status'], response['body'], headers)
+
         # Get the HTTP component they want
         case component
         when :status  then response['code'].to_i
         # facebook returns the headers as an array of k/v pairs, but we want a regular hash
         when :headers then headers
         # (see note in regular api method about JSON parsing)
-        else json_body(response)
+        else GraphCollection.evaluate(result, original_api)
         end
       end
 

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -218,7 +218,7 @@ describe "Koala::Facebook::API" do
 
     it "passes the results through GraphCollection.evaluate" do
       allow(@service).to receive(:api).and_return(dummy_response)
-      expect(Koala::Facebook::API::GraphCollection).to receive(:evaluate).with(dummy_response.data, @service)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:evaluate).with(dummy_response, @service)
       @service.graph_call("/me")
     end
 

--- a/spec/cases/graph_collection_spec.rb
+++ b/spec/cases/graph_collection_spec.rb
@@ -4,12 +4,13 @@ describe Koala::Facebook::API::GraphCollection do
   let(:paging){ {"paging" => true} }
 
   before(:each) do
+    @headers = {'Content-Type' => 'application/json'}
     @data = {
       "data" => [1, 2, 'three'],
       "paging" => paging,
       "summary" => [3]
     }
-    @result = Koala::HTTPService::Response.new(200, @data.to_json, {})
+    @result = Koala::HTTPService::Response.new(200, @data.to_json, @headers)
     @api = Koala::Facebook::API.new("123")
     @collection = Koala::Facebook::API::GraphCollection.new(@result, @api)
   end
@@ -45,6 +46,10 @@ describe Koala::Facebook::API::GraphCollection do
 
   it "sets the API to the provided API" do
     expect(@collection.api).to eq(@api)
+  end
+
+  it "sets the headers correctly" do
+    expect(@collection.headers).to eq(@headers)
   end
 
   describe "when getting a whole page" do

--- a/spec/cases/graph_collection_spec.rb
+++ b/spec/cases/graph_collection_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 describe Koala::Facebook::API::GraphCollection do
-  let(:paging){ {:paging => true} }
+  let(:paging){ {"paging" => true} }
 
   before(:each) do
-    @result = {
-      "data" => [1, 2, :three],
+    @data = {
+      "data" => [1, 2, 'three'],
       "paging" => paging,
       "summary" => [3]
     }
+    @result = Koala::HTTPService::Response.new(200, @data.to_json, {})
     @api = Koala::Facebook::API.new("123")
     @collection = Koala::Facebook::API::GraphCollection.new(@result, @api)
   end
@@ -22,7 +23,7 @@ describe Koala::Facebook::API::GraphCollection do
   end
 
   it "contains the result data" do
-    @result["data"].each_with_index {|r, i| expect(@collection[i]).to eq(r)}
+    @data["data"].each_with_index {|r, i| expect(@collection[i]).to eq(r)}
   end
 
   it "has a read-only paging attribute" do
@@ -31,15 +32,15 @@ describe Koala::Facebook::API::GraphCollection do
   end
 
   it "sets paging to results['paging']" do
-    expect(@collection.paging).to eq(@result["paging"])
+    expect(@collection.paging).to eq(@data["paging"])
   end
 
   it "sets summary to results['summary']" do
-    expect(@collection.summary).to eq(@result["summary"])
+    expect(@collection.summary).to eq(@data["summary"])
   end
 
   it "sets raw_response to the original results" do
-    expect(@collection.raw_response).to eq(@result)
+    expect(@collection.raw_response).to eq(@result.data)
   end
 
   it "sets the API to the provided API" do
@@ -55,19 +56,21 @@ describe Koala::Facebook::API::GraphCollection do
       @base = double("base")
       @args = {"a" => 1}
       @page_of_results = double("page of results")
+      @result = Koala::HTTPService::Response.new(200, @second_page.to_json, {})
+      @result.data
     end
 
     it "should return the previous page of results" do
       expect(@collection).to receive(:previous_page_params).and_return([@base, @args])
-      expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(Koala::HTTPService::Response.new(200, @second_page.to_json, {}))
-      expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
+      expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(@result)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(@result, @api).and_return(@page_of_results)
       expect(@collection.previous_page).to eq(@page_of_results)
     end
 
     it "should return the next page of results" do
       expect(@collection).to receive(:next_page_params).and_return([@base, @args])
-      expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(Koala::HTTPService::Response.new(200, @second_page.to_json, {}))
-      expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(@second_page, @api).and_return(@page_of_results)
+      expect(@api).to receive(:api).with(@base, @args, anything, anything).and_return(@result)
+      expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(@result, @api).and_return(@page_of_results)
 
       expect(@collection.next_page).to eq(@page_of_results)
     end
@@ -121,9 +124,11 @@ describe Koala::Facebook::API::GraphCollection do
   end
 
   describe ".evaluate" do
-    it "returns the original result if it's provided a non-hash result" do
-      result = []
-      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
+    it "returns the body of the original response if it's provided a Response with a non-hash data key" do
+      result = double('fake response')
+      allow(result).to receive(:is_a?).with(Hash).and_return(false)
+      allow(result).to receive(:data).and_return([])
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq([])
     end
 
     it "returns the original result if it's provided a nil result" do
@@ -131,18 +136,21 @@ describe Koala::Facebook::API::GraphCollection do
       expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
     end
 
-    it "returns the original result if the result doesn't have a data key" do
-      result = {"paging" => {}}
-      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
+    it "returns the original result body if the result doesn't have a data key" do
+      paging = {"paging" => {}}
+      result = Koala::HTTPService::Response.new(200, paging.to_json, {})
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(paging)
     end
 
     it "returns the original result if the result's data key isn't an array" do
-      result = {"data" => {}, "paging" => {}}
-      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(result)
+      body = {"data" => {}, "paging" => {}}
+      result = Koala::HTTPService::Response.new(200, body.to_json, {})
+      expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(body)
     end
 
     it "returns a new GraphCollection of the result if it has an array data key and a paging key" do
-      result = {"data" => [], "paging" => {}}
+      body = {"data" => [], "paging" => {}}
+      result = Koala::HTTPService::Response.new(200, body.to_json, {})
       expected = :foo
       expect(Koala::Facebook::API::GraphCollection).to receive(:new).with(result, @api).and_return(expected)
       expect(Koala::Facebook::API::GraphCollection.evaluate(result, @api)).to eq(expected)


### PR DESCRIPTION
Related to discussions in #582, solving #522  

Exposes headers in every koala response, instead of having to make a separate response just to retrieve the headers. @arsduo this probably needs a good bit of auditing since I only half know what I am doing here :cold_sweat: 

- [x] My PR has tests and they pass!
- [ ] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
- [x] The PR is based on the most recent master commit and has no merge conflicts.

Normal tests are fine. Live tests are failing. The failures are documented in a following comment.