### PR TITLE
Allow default access token and other settings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,8 +18,13 @@ should (in theory) require no code changes. (Let me know if you run into any iss
 * API#search now requires a "type"/:type argument, matching Facebook's behavior (improving their
   cryptic error message)
 
+New features:
+
+* Koala now supports global configuration for tokens, secrets, etc! See the readme.
+
 Updated features:
 
+* Koala.config now uses a dedicated Koala::Configuration object
 * TestUser#befriend will provide the appsecret_proof if a secret is set (thanks, kwasimensah!)
 * API#search now requires an object type parameter to be included, matching Facebook's API (#575)
 

--- a/lib/koala.rb
+++ b/lib/koala.rb
@@ -38,12 +38,8 @@ module Koala
     end
 
     # Allows you to control various Koala configuration options.
-    # Notable options:
-    #   * server endpoints: you can override any or all the server endpoints
-    #   (see HTTPService::DEFAULT_SERVERS) if you want to run requests through
-    #   other servers.
-    #   * api_version: controls which Facebook API version to use (v1.0, v2.0,
-    #   etc)
+    # NOTE: this is not currently threadsafe.
+    # See Koala::Configuration.
     def config
       @config ||= Configuration.new
     end

--- a/lib/koala.rb
+++ b/lib/koala.rb
@@ -14,6 +14,7 @@ require 'koala/test_users'
 require 'koala/http_service'
 
 # miscellaneous
+require 'koala/configuration'
 require 'koala/utils'
 require 'koala/version'
 require 'ostruct'
@@ -44,7 +45,7 @@ module Koala
     #   * api_version: controls which Facebook API version to use (v1.0, v2.0,
     #   etc)
     def config
-      @config ||= OpenStruct.new(HTTPService::DEFAULT_SERVERS)
+      @config ||= Configuration.new
     end
 
     # Used for testing.

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -15,7 +15,7 @@ module Koala
       #                 https://developers.facebook.com/docs/graph-api/securing-requests/)
       # @note If no access token is provided, you can only access some public information.
       # @return [Koala::Facebook::API] the API client
-      def initialize(access_token = nil, app_secret = nil)
+      def initialize(access_token = Koala.config.access_token, app_secret = Koala.config.app_secret)
         @access_token = access_token
         @app_secret = app_secret
       end

--- a/lib/koala/configuration.rb
+++ b/lib/koala/configuration.rb
@@ -1,0 +1,49 @@
+# Global configuration for Koala.
+class Koala::Configuration
+  # The default access token to be used if none is otherwise supplied.
+  attr_accessor :access_token
+
+  # The default app secret value to be used if none is otherwise supplied.
+  attr_accessor :app_secret
+
+  # The default application ID to use if none is otherwise supplied.
+  attr_accessor :app_id
+
+  # The default app access token to be used if none is otherwise supplied.
+  attr_accessor :app_access_token
+
+  # The default API version to use if none is otherwise specified.
+  attr_accessor :api_version
+
+  # The default value to use for the oauth_callback_url if no other is provided.
+  attr_accessor :oauth_callback_url
+
+  # Whether to preserve arrays in arguments, which are expected by certain FB APIs (see the ads API
+  # in particular, https://developers.facebook.com/docs/marketing-api/adgroup/v2.4)
+  attr_accessor :preserve_form_arguments
+
+  # The server to use for Graph API requests
+  attr_accessor :graph_server
+
+  # The server to use when constructing dialog URLs.
+  attr_accessor :dialog_host
+
+  # Certain Facebook services (beta, video) require you to access different
+  # servers. If you're using your own servers, for instance, for a proxy,
+  # you can change both the matcher (what value to change when updating the URL) and the
+  # replacement values (what to add).
+  #
+  # So, for instance, to use the beta stack, we match on .facebook and change it to .beta.facebook.
+  # If you're talking to fbproxy.mycompany.com, you could set up beta.fbproxy.mycompany.com for
+  # FB's beta tier, and set the matcher to /\.fbproxy/ and the beta_replace to '.beta.fbproxy'.
+  attr_accessor :host_path_matcher
+  attr_accessor :video_replace
+  attr_accessor :beta_replace
+
+  def initialize
+    # Default to our default values.
+    Koala::HTTPService::DEFAULT_SERVERS.each_pair do |key, value|
+      self.public_send("#{key}=", value)
+    end
+  end
+end

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -24,17 +24,11 @@ module Koala
       builder.adapter Faraday.default_adapter
     end
 
-    # Default servers for Facebook. These are read into the config OpenStruct,
-    # and can be overridden via Koala.config.
+    # Default server information for Facebook. These can be overridden by setting config values.
+    # See Koala.config.
     DEFAULT_SERVERS = {
       :graph_server => 'graph.facebook.com',
       :dialog_host => 'www.facebook.com',
-      # certain Facebook services (beta, video) require you to access different
-      # servers. If you're using your own servers, for instance, for a proxy,
-      # you can change both the matcher and the replacement values.
-      # So for instance, if you're talking to fbproxy.mycompany.com, you could
-      # set up beta.fbproxy.mycompany.com for FB's beta tier, and set the
-      # matcher to /\.fbproxy/ and the beta_replace to '.beta.fbproxy'.
       :host_path_matcher => /\.facebook/,
       :video_replace => '-video.facebook',
       :beta_replace => '.beta.facebook'

--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -12,10 +12,10 @@ module Koala
       # @param app_id [String, Integer] a Facebook application ID
       # @param app_secret a Facebook application secret
       # @param oauth_callback_url the URL in your app to which users authenticating with OAuth will be sent
-      def initialize(app_id, app_secret, oauth_callback_url = nil)
-        @app_id = app_id
-        @app_secret = app_secret
-        @oauth_callback_url = oauth_callback_url
+      def initialize(app_id = nil, app_secret = nil, oauth_callback_url = nil)
+        @app_id = app_id || Koala.config.app_id
+        @app_secret = app_secret || Koala.config.app_secret
+        @oauth_callback_url = oauth_callback_url || Koala.config.oauth_callback_url
       end
 
       # Parses the cookie set Facebook's JavaScript SDK.

--- a/lib/koala/realtime_updates.rb
+++ b/lib/koala/realtime_updates.rb
@@ -23,9 +23,9 @@ module Koala
       #
       # @raise ArgumentError if the application ID and one of the app access token or the secret are not provided.
       def initialize(options = {})
-        @app_id = options[:app_id]
-        @app_access_token = options[:app_access_token]
-        @secret = options[:secret]
+        @app_id = options[:app_id] || Koala.config.app_id
+        @app_access_token = options[:app_access_token] || Koala.config.app_access_token
+        @secret = options[:secret] || Koala.config.app_secret
         unless @app_id && (@app_access_token || @secret) # make sure we have what we need
           raise ArgumentError, "Initialize must receive a hash with :app_id and either :app_access_token or :secret! (received #{options.inspect})"
         end

--- a/lib/koala/test_users.rb
+++ b/lib/koala/test_users.rb
@@ -14,7 +14,6 @@ module Koala
     #
     # See http://developers.facebook.com/docs/test_users/.
     class TestUsers
-
       # The application API interface used to communicate with Facebook.
       # @return [Koala::Facebook::API]
       attr_reader :api
@@ -31,9 +30,10 @@ module Koala
       #
       # @raise ArgumentError if the application ID and one of the app access token or the secret are not provided.
       def initialize(options = {})
-        @app_id = options[:app_id]
-        @app_access_token = options[:app_access_token]
-        @secret = options[:secret]
+        @app_id = options[:app_id] || Koala.config.app_id
+        @app_access_token = options[:app_access_token] || Koala.config.app_access_token
+        @secret = options[:secret] || Koala.config.app_secret
+
         unless @app_id && (@app_access_token || @secret) # make sure we have what we need
           raise ArgumentError, "Initialize must receive a hash with :app_id and either :app_access_token or :secret! (received #{options.inspect})"
         end

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -6,6 +6,26 @@ describe "Koala::Facebook::API" do
   end
   let(:dummy_response) { double("fake response", data: {}, status: 200, body: "", headers: {}) }
 
+  it "defaults to the globally configured token if one's provided" do
+    token = "Foo"
+
+    Koala.configure do |config|
+      config.access_token = token
+    end
+
+    expect(Koala::Facebook::API.new.access_token).to eq(token)
+  end
+
+  it "defaults to the globally configured app_secret if one's provided" do
+    app_secret = "Foo"
+
+    Koala.configure do |config|
+      config.app_secret = app_secret
+    end
+
+    expect(Koala::Facebook::API.new.app_secret).to eq(app_secret)
+  end
+
   it "doesn't include an access token if none was given" do
     expect(Koala).to receive(:make_request).with(
       anything,
@@ -44,18 +64,6 @@ describe "Koala::Facebook::API" do
 
     args = {}.freeze
     service.api('anything', args)
-  end
-
-  it "has an attr_reader for access token" do
-    token = 'adfadf'
-    service = Koala::Facebook::API.new token
-    expect(service.access_token).to eq(token)
-  end
-
-  it "has an attr_reader for app_secret" do
-    secret = double
-    service = Koala::Facebook::API.new(@token, secret)
-    expect(service.app_secret).to eq(secret)
   end
 
   it "turns arrays of non-enumerables into comma-separated arguments by default" do

--- a/spec/cases/configuration_spec.rb
+++ b/spec/cases/configuration_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe Koala::Configuration do
+  let(:config) { Koala::Configuration.new }
+
+  it "defaults the HTTPService's DEFAULT_SERVERS" do
+    Koala::HTTPService::DEFAULT_SERVERS.each_pair do |key, value|
+      expect(config.public_send(key)).to eq(value)
+    end
+  end
+end

--- a/spec/cases/http_service/request_spec.rb
+++ b/spec/cases/http_service/request_spec.rb
@@ -66,17 +66,19 @@ module Koala
           end
 
           context "set by Koala.config" do
-            let(:version) { "v2.1" }
+            let(:version) { "v2.7" }
 
             before :each do
-              allow(Koala.config).to receive(:api_version).and_return(version)
+              Koala.configure do |config|
+                config.api_version = version
+              end
             end
 
             it_should_behave_like :including_the_version
           end
 
           context "set in options" do
-            let(:version) { "v2.1" }
+            let(:version) { "v2.8" }
 
             let(:options) { {api_version: version} }
 

--- a/spec/cases/koala_spec.rb
+++ b/spec/cases/koala_spec.rb
@@ -31,9 +31,7 @@ describe Koala do
 
   describe ".configure" do
     it "yields a configurable object" do
-      expect {
-        Koala.configure {|c| c.foo = "bar"}
-      }.not_to raise_exception
+      Koala.configure {|c| expect(c).to be_a(Koala::Configuration)}
     end
 
     it "caches the config (singleton)" do
@@ -56,5 +54,4 @@ describe Koala do
       expect(Koala.config.graph_server).to eq("some-new.graph_server.com")
     end
   end
-
 end

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -53,6 +53,45 @@ describe "Koala::Facebook::OAuth" do
              @oauth.app_secret == @secret &&
              @oauth.oauth_callback_url == nil).to be_truthy
     end
+
+    context "with global defaults" do
+      let(:app_id) { :app_id }
+      let(:app_secret) { :app_secret }
+      let(:oauth_callback_url) { :oauth_callback_url }
+
+      before :each do
+        Koala.configure do |config|
+          config.app_id = app_id
+          config.app_secret = app_secret
+          config.oauth_callback_url = oauth_callback_url
+        end
+      end
+
+      it "defaults to the configured data if not otherwise provided" do
+        oauth = Koala::Facebook::OAuth.new
+        expect(oauth.app_id).to eq(app_id)
+        expect(oauth.app_secret).to eq(app_secret)
+        expect(oauth.oauth_callback_url).to eq(oauth_callback_url)
+      end
+
+      it "lets you override app_id" do
+        other_value = :another_id
+        oauth = Koala::Facebook::OAuth.new(other_value)
+        expect(oauth.app_id).to eq(other_value)
+      end
+
+      it "lets you override secret" do
+        other_value = :another_secret
+        oauth = Koala::Facebook::OAuth.new(nil, other_value)
+        expect(oauth.app_secret).to eq(other_value)
+      end
+
+      it "lets you override app_id" do
+        other_value = :another_token
+        oauth = Koala::Facebook::OAuth.new(nil, nil, other_value)
+        expect(oauth.oauth_callback_url).to eq(other_value)
+      end
+    end
   end
 
   describe "for cookie parsing" do

--- a/spec/cases/realtime_updates_spec.rb
+++ b/spec/cases/realtime_updates_spec.rb
@@ -36,6 +36,45 @@ describe "Koala::Facebook::RealtimeUpdates" do
       expect(updates).to be_a(Koala::Facebook::RealtimeUpdates)
     end
 
+    context "with global defaults" do
+      let(:app_id) { :app_id }
+      let(:app_secret) { :app_secret }
+      let(:app_access_token) { :app_access_token }
+
+      before :each do
+        Koala.configure do |config|
+          config.app_id = app_id
+          config.app_secret = app_secret
+          config.app_access_token = app_access_token
+        end
+      end
+
+      it "defaults to the configured data if not otherwise provided" do
+        rtu = Koala::Facebook::RealtimeUpdates.new
+        expect(rtu.app_id).to eq(app_id)
+        expect(rtu.secret).to eq(app_secret)
+        expect(rtu.app_access_token).to eq(app_access_token)
+      end
+
+      it "lets you override app_id" do
+        other_value = :another_id
+        rtu = Koala::Facebook::RealtimeUpdates.new(app_id: other_value)
+        expect(rtu.app_id).to eq(other_value)
+      end
+
+      it "lets you override secret" do
+        other_value = :another_secret
+        rtu = Koala::Facebook::RealtimeUpdates.new(secret: other_value)
+        expect(rtu.secret).to eq(other_value)
+      end
+
+      it "lets you override app_id" do
+        other_value = :another_token
+        rtu = Koala::Facebook::RealtimeUpdates.new(app_access_token: other_value)
+        expect(rtu.app_access_token).to eq(other_value)
+      end
+    end
+
     # attributes
     it "allows read access to app_id" do
       # in Ruby 1.9, .method returns symbols

--- a/spec/cases/test_users_spec.rb
+++ b/spec/cases/test_users_spec.rb
@@ -40,12 +40,52 @@ describe "Koala::Facebook::TestUsers" do
       expect(test_users).to be_a(Koala::Facebook::TestUsers)
     end
 
+    context "with global defaults" do
+      let(:app_id) { :app_id }
+      let(:app_secret) { :app_secret }
+      let(:app_access_token) { :app_access_token }
+
+      before :each do
+        Koala.configure do |config|
+          config.app_id = app_id
+          config.app_secret = app_secret
+          config.app_access_token = app_access_token
+        end
+      end
+
+      it "defaults to the configured data if not otherwise provided" do
+        test_users = Koala::Facebook::TestUsers.new
+        expect(test_users.app_id).to eq(app_id)
+        expect(test_users.secret).to eq(app_secret)
+        expect(test_users.app_access_token).to eq(app_access_token)
+      end
+
+      it "lets you override app_id" do
+        other_value = :another_id
+        test_users = Koala::Facebook::TestUsers.new(app_id: other_value)
+        expect(test_users.app_id).to eq(other_value)
+      end
+
+      it "lets you override secret" do
+        other_value = :another_secret
+        test_users = Koala::Facebook::TestUsers.new(secret: other_value)
+        expect(test_users.secret).to eq(other_value)
+      end
+
+      it "lets you override app_id" do
+        other_value = :another_token
+        test_users = Koala::Facebook::TestUsers.new(app_access_token: other_value)
+        expect(test_users.app_access_token).to eq(other_value)
+      end
+    end
+
+
     it "uses the OAuth class to fetch a token when provided an app_id and a secret" do
       oauth = Koala::Facebook::OAuth.new(@app_id, @secret)
       token = oauth.get_app_access_token
       expect(oauth).to receive(:get_app_access_token).and_return(token)
       expect(Koala::Facebook::OAuth).to receive(:new).with(@app_id, @secret).and_return(oauth)
-      test_users = Koala::Facebook::TestUsers.new(:app_id => @app_id, :secret => @secret)
+      Koala::Facebook::TestUsers.new(:app_id => @app_id, :secret => @secret)
     end
 
     # attributes


### PR DESCRIPTION
One use case that I've heard several times (and that a number of of other API gems support) is setting a default access token, secret, etc. to be used across an entire application. Most apps (unlike the social media tool Koala was originally made to power) only use one access token, so having a central ability to configure that would be hugely useful.

This PR implements an expanded Koala::Configuration object. Instead of an OpenStruct, it's now a class with defined parameters, and is used by the various APIs and the OAuth class.

**Note**: Configuration is not yet threadsafe. I'll implement that after I have a chance to see how some other libraries are doing it.

Closes #226.