### PR TITLE
Avoid unnecessary app_access_token fetch in RealtimeUpdates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@ Updated features:
 * Koala.config now uses a dedicated Koala::Configuration object
 * TestUser#befriend will provide the appsecret_proof if a secret is set (thanks, kwasimensah!)
 * API#search now requires an object type parameter to be included, matching Facebook's API (#575)
+* RealtimeUpdates will now only fetch the app access token if necessary, avoiding unnecessary calls
 
 Removed features:
 

--- a/spec/cases/realtime_updates_spec.rb
+++ b/spec/cases/realtime_updates_spec.rb
@@ -106,25 +106,24 @@ describe "Koala::Facebook::RealtimeUpdates" do
       expect(updates).to be_a(Koala::Facebook::RealtimeUpdates)
     end
 
-    it "fetches an app_token from Facebook when provided an app_id and a secret" do
-      updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
-      expect(updates.app_access_token).not_to be_nil
-    end
-
-    it "uses the OAuth class to fetch a token when provided an app_id and a secret" do
-      oauth = Koala::Facebook::OAuth.new(@app_id, @secret)
-      token = oauth.get_app_access_token
-      expect(oauth).to receive(:get_app_access_token).and_return(token)
-      expect(Koala::Facebook::OAuth).to receive(:new).with(@app_id, @secret).and_return(oauth)
-      updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
-    end
-
-    it "sets up the with the app acces token" do
+    it "sets up the API with the app access token" do
       updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :app_access_token => @app_access_token)
       expect(updates.api).to be_a(Koala::Facebook::API)
       expect(updates.api.access_token).to eq(@app_access_token)
     end
+  end
 
+  describe "#app_access_token" do
+    it "fetches an app_token from Facebook when provided an app_id and a secret" do
+      # integration test
+      updates = Koala::Facebook::RealtimeUpdates.new(:app_id => @app_id, :secret => @secret)
+      expect(updates.app_access_token).not_to be_nil
+    end
+
+    it "returns the provided token if provided" do
+      updates = Koala::Facebook::RealtimeUpdates.new(app_id: @app_id, app_access_token: @app_access_token)
+      expect(updates.app_access_token).to eq(@app_access_token)
+    end
   end
 
   describe "#subscribe" do


### PR DESCRIPTION
In #593, @rusikf pointed out that RealtimeUpdates makes a call to Facebook to fetch the app_access_token even when all you want to do is validate an update from Facebook, which doesn't require the token. This PR refactors that class so the app_access_token call is only made when needed.