### PR TITLE
Drop Json version to 1.8 to support Rails 4.2.x

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency("faraday")
   gem.add_runtime_dependency("addressable")
-  gem.add_runtime_dependency("json", ">= 2.0")
+  gem.add_runtime_dependency("json", "~> 1.8")
 end


### PR DESCRIPTION
Fixes #595 
Json 1.8.5 actually included some fixes to support Rails 4.2 https://github.com/flori/json/issues/311

Koala can't be used with Rails 4.2 right now because it depends on Json 2, whereas Rails 4.2 expects Json 1.x. Dropping the version to 1.8 fixes the incompatibility.

- [ ] My PR has tests and they pass!
- [ ] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
- [x] The PR is based on the most recent master commit and has no merge conflicts.
