### PR TITLE
Correct PR link in changeling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,7 +36,7 @@ Removed features:
 * Removed support for the Rest API, since Facebook removed support for it (#568)
 * Removed support for FQL, which Facebook removed on August 8, 2016 (#569)
 * Removed legacy duplication of serveral constants in the Koala module (#569)
-* Removed API#get_comments_for_urls, which pointed to a no-longer-extant endpoint(#570)
+* Removed API#get_comments_for_urls, which pointed to a no-longer-extant endpoint(#577)
 
 Internal improvements:
 


### PR DESCRIPTION
Just a trivial change while reading changelog.
#577 change was wrongly labeled as #570 