### PR TITLE
Handle FB truncating batch

### DIFF
--- a/lib/koala/api/graph_batch_api.rb
+++ b/lib/koala/api/graph_batch_api.rb
@@ -45,7 +45,9 @@ module Koala
         return [] if batch_calls.empty?
 
         batch_results = []
-        batch_calls.each_slice(MAX_CALLS) do |batch|
+        until batch_calls.empty? do
+          batch = batch_calls.shift(MAX_CALLS)
+
           # Turn the call args collected into what facebook expects
           args = {"batch" => batch_args(batch)}
           batch.each do |call|
@@ -55,7 +57,13 @@ module Koala
           original_api.graph_call("/", args, "post", http_options) do |response|
             raise bad_response if response.nil?
 
-            batch_results += generate_results(response, batch)
+            # FB sometimes truncates the submission batch. dhm thinks it may be limiting create actions
+            # without erroring
+            slice_results = generate_results(response, batch)
+            batch_results += slice_results
+            if slice_results.length < batch.length
+              batch_calls.unshift(*batch[slice_results.length .. batch.length])
+            end
           end
         end
 

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -474,12 +474,17 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
   end
 
   describe '#big_batches' do
+    before :all do
+      @random = Random.new
+    end
     before :each do
       payload = [{code: 200, headers: [{name: "Content-Type", value: "text/javascript; charset=UTF-8"}], body: "{\"id\":\"1234\"}"}]
       allow(Koala).to receive(:make_request) do |_request, args, _verb, _options|
         request_count = JSON.parse(args['batch']).length
         expect(request_count).to be <= 50   # check FB's limit
-        Koala::HTTPService::Response.new(200, (payload * request_count).to_json, {})
+        # simulate FB's result truncation
+        response_count = request_count > 35 ? request_count - @random.rand(15) : request_count
+        Koala::HTTPService::Response.new(200, (payload * response_count).to_json, {})
       end
     end
 


### PR DESCRIPTION
Sometimes FB is responding with fewer than the submitted batch. I have been logging it for a while, and it seems to be a simple truncation. I've asked FB for confirmation and clarification. (My code often submits O(10^5) commands at a time.) I believe the truncation has to do w create commands.

I'm not sure how, for LIVE test, to disable the `before :each allow.. and return()` logic so that it really submits the request to FB. 
----
Thanks for submitting a pull request to Koala! A huge portion of the gem has been built by awesome people (like you) from the Ruby community.

Here are a few things that will help get your pull request merged in quickly. None of this is required -- you can delete anything not relevant. If in doubt, open the PR! I want to help.

[x] My PR has tests and they pass!
[x] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
[x] The PR is based on the most recent master commit and has no merge conflicts.

If you have any questions, feel free to open an issue or comment on your PR!

Note: Koala has a [code of conduct](https://github.com/arsduo/koala/blob/master/code_of_conduct.md). Check it out.