### PR TITLE
Remove test files and reduce size of built gem 

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |gem|
   gem.email       = "alex@alexkoppel.com"
 
   gem.require_paths  = ["lib"]
-  gem.files          = `git ls-files`.split("\n")
-  gem.test_files     = `git ls-files -- {test,spec,features}/*`.split("\n")
-  gem.executables    = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  gem.files          = Dir[File.join("lib", "**", "*")]
 
   gem.extra_rdoc_files = ["readme.md", "changelog.md"]
   gem.rdoc_options     = ["--line-numbers", "--inline-source", "--title", "Koala"]


### PR DESCRIPTION
I noticed that koala went from 180KB (v2.5.0) to current **5.26MB**, and a check showed that `spec/` was being included in the built gem. End users don't need test files - just _code_, documentation and executables (not applicable here).

Also, the `test_files` method is no longer a part of the rubygems spec: https://github.com/rubygems/rubygems/commit/429f883210f8b2b38ea310f7fc6636cd0e456d5c

[x] The PR is based on the most recent master commit and has no merge conflicts.

This brings down size of the `.gem` to ~**44 KB**.