### PR TITLE
Cast any relative_url in Batches to string type

### DIFF
--- a/lib/koala/api/batch_operation.rb
+++ b/lib/koala/api/batch_operation.rb
@@ -41,7 +41,7 @@ module Koala
 
           response = {
             :method => @method.to_s,
-            :relative_url => @url,
+            :relative_url => @url.to_s,
           }
 
           # handle batch-level arguments, such as name, depends_on, and attached_files

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -112,6 +112,13 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
     describe "#to_batch_params" do
       describe "handling arguments and URLs" do
         shared_examples_for "request with no body" do
+          it "casts the URL to string" do
+            @args[:url] = url = 1923883983
+            allow(Koala.http_service).to receive(:encode_params).and_return('')
+
+            expect(Koala::Facebook::GraphBatchAPI::BatchOperation.new(@args).to_batch_params(nil, nil)[:relative_url]).to eq("#{url}")
+          end
+
           it "adds the args to the URL string, with ? if no args previously present" do
             test_args = "foo"
             @args[:url] = url = "/"


### PR DESCRIPTION
First of all it's pretty obvious that URL should be a string,
but the real problem that if you pass and facebook object id as parameter
to Batch API, like `batch.get_object(192312983)` you end-up with
500 - 'an unknown error' from the Facebook.

So, doesn't work anymore with number, but id does with strings :hooray:

<img width="735" alt="screen shot 2017-07-13 at 17 32 02" src="https://user-images.githubusercontent.com/208430/28206830-282469b8-6890-11e7-827a-a7cb87754465.png">

<img width="966" alt="screen shot 2017-07-14 at 12 35 44" src="https://user-images.githubusercontent.com/208430/28207072-01ef6238-6891-11e7-9d89-28cca9b77aee.png">


[x] My PR has tests and they pass!
[x] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
[x] The PR is based on the most recent master commit and has no merge conflicts.
