### PR TITLE
Remove json gem dependency

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency("faraday")
   gem.add_runtime_dependency("addressable")
-  gem.add_runtime_dependency("json", ">= 1.8")
 end


### PR DESCRIPTION
All modern Rubies ship JSON as part of stdlib. Many other gems like [Rails have also removed json](https://github.com/rails/rails/pull/23453). Using the gem actually hurts multi-platform support due to build difficulties on Windows.

* [x] My PR has tests and they pass!
* [x] The PR is based on the most recent master commit and has no merge conflicts.
