### PR TITLE
Pin faraday version

### DIFF
--- a/koala.gemspec
+++ b/koala.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency("faraday")
+  gem.add_runtime_dependency("faraday", "~> 0.11", "< 0.12.2")
   gem.add_runtime_dependency("addressable")
   gem.add_runtime_dependency("json", ">= 1.8")
 end


### PR DESCRIPTION
It seems that [a commit in faraday](https://github.com/lostisland/faraday/commit/b2e8bcc04feee5202701e014d03f5c0db7d1fb36) broke [a test in koala](https://travis-ci.org/arsduo/koala/jobs/258756500\#L1235-L1272), and Koala is not compatible with any Faraday versions that ship with the commit. The faraday version should be pinned until a fix is applied to it.

[1]: https://github.com/lostisland/faraday/commit/b2e8bcc04feee5202701e014d03f5c0db7d1fb36
[2]: https://travis-ci.org/arsduo/koala/jobs/258756500\#L1235-L1272

* [x] My PR has tests and they pass!
* [x] The PR is based on the most recent master commit and has no merge conflicts.