### PR TITLE
Use GET HTTP Method to generate an app access token

### DIFF
--- a/lib/koala/oauth.rb
+++ b/lib/koala/oauth.rb
@@ -186,7 +186,7 @@ module Koala
       # @return the application access token and other information (expiration, etc.)
       def get_app_access_token_info(options = {})
         # convenience method to get a the application's sessionless access token
-        get_token_from_server({:grant_type => 'client_credentials'}, true, options)
+        get_token_from_server({:grant_type => 'client_credentials'}, false, options)
       end
 
       # Fetches the application's access token (ignoring expiration and other info).

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -538,7 +538,7 @@ describe "Koala::Facebook::OAuth" do
 
         it "passes on any options provided to make_request" do
           options = {:a => 2}
-          expect(Koala).to receive(:make_request).with(anything, anything, anything, hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
+          expect(Koala).to receive(:make_request).with(anything, anything, 'get', hash_including(options)).and_return(Koala::HTTPService::Response.new(200, "", {}))
           @oauth.get_app_access_token(options)
         end
       end

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -613,7 +613,7 @@ describe "Koala::Facebook::OAuth" do
         end
 
         it "fetches a proper token string from Facebook when asked for the app token" do
-          result = @oauth.send(:fetch_token_string, {:grant_type => 'client_credentials'}, true)
+          result = @oauth.send(:fetch_token_string, {:grant_type => 'client_credentials'})
           expect(result).to match(/^access_token/)
         end
       end

--- a/spec/fixtures/mock_facebook_responses.yml
+++ b/spec/fixtures/mock_facebook_responses.yml
@@ -306,7 +306,7 @@ graph_api:
       get:
         <<: *oauth_error
     client_id=<%= APP_ID %>&client_secret=<%= SECRET %>&grant_type=client_credentials:
-      post:
+      get:
         no_token: access_token=<%= APP_ACCESS_TOKEN %>
     client_id=<%= APP_ID %>&client_secret=<%= SECRET %>&fb_exchange_token=<%= ACCESS_TOKEN %>&grant_type=fb_exchange_token:
       post:


### PR DESCRIPTION
In Facebook Document, use GET HTTP Method to generate an app access token.
https://developers.facebook.com/docs/facebook-login/access-tokens?locale=en_US#apptokens

POST is okay,  however according to the Document, use GET HTTP Method.

- [x] My PR has tests and they pass!
- [ ] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
- [x] The PR is based on the most recent master commit and has no merge conflicts.
