### PR TITLE
Do NOT check for OAuthException code

### DIFF
--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -11,10 +11,6 @@ module Koala
         @headers = headers
       end
 
-      # Facebook has a set of standardized error codes, some of which represent problems with the
-      # token.
-      AUTHENTICATION_ERROR_CODES = [102, 190, 450, 452, 2500]
-
       # Facebook can return debug information in the response headers -- see
       # https://developers.facebook.com/docs/graph-api/using-graph-api#bugdebug
       DEBUG_HEADERS = ["x-fb-debug", "x-fb-rev", "x-fb-trace-id"]
@@ -38,10 +34,7 @@ module Koala
       end
 
       def auth_error?
-        # tbh, I'm not sure why we restrict Facebook-reported OAuthExceptions to only those without
-        # codes or whose codes match the list above -- let's investigate changing this later.
-        error_info['type'] == 'OAuthException' &&
-          (!error_info['code'] || AUTHENTICATION_ERROR_CODES.include?(error_info['code'].to_i))
+        error_info['type'] == 'OAuthException'
       end
 
       def error_info

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 module Koala
   module Facebook
     RSpec.describe GraphErrorChecker do
-      it "defines a set of AUTHENTICATION_ERROR_CODES" do
-        expect(GraphErrorChecker::AUTHENTICATION_ERROR_CODES).to match_array([102, 190, 450, 452, 2500])
-      end
-
       it "defines a set of DEBUG_HEADERS" do
         expect(GraphErrorChecker::DEBUG_HEADERS).to match_array([
           "x-fb-rev",
@@ -94,13 +90,6 @@ module Koala
             it "if FB says it's an OAuthException and it has no code" do
               body.replace({"error" => {"type" => "OAuthException"}}.to_json)
               expect(error).to be_an(AuthenticationError)
-            end
-
-            GraphErrorChecker::AUTHENTICATION_ERROR_CODES.each do |error_code|
-              it "if FB says it's an OAuthException and it has code #{error_code}" do
-                body.replace({"error" => {"type" => "OAuthException", "code" => error_code}}.to_json)
-                expect(error).to be_an(AuthenticationError)
-              end
             end
           end
 


### PR DESCRIPTION
I encountered a situation where I receive a Facebook error with code
`100` and type `OAuthException`. I don’t think we need to check for
codes to decide if it is an `AuthenticationError` or `ClientError`.

Thanks for submitting a pull request to Koala! A huge portion of the gem has been built by awesome people (like you) from the Ruby community.

Here are a few things that will help get your pull request merged in quickly. None of this is required -- you can delete anything not relevant. If in doubt, open the PR! I want to help.

[ ] My PR has tests and they pass!
[ ] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
[ ] The PR is based on the most recent master commit and has no merge conflicts.

If you have any questions, feel free to open an issue or comment on your PR!

Note: Koala has a [code of conduct](https://github.com/arsduo/koala/blob/master/code_of_conduct.md). Check it out.