### PR TITLE
Signify error code 104 as an AuthenticationError

### DIFF
--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -13,7 +13,7 @@ module Koala
 
       # Facebook has a set of standardized error codes, some of which represent problems with the
       # token.
-      AUTHENTICATION_ERROR_CODES = [102, 190, 450, 452, 2500]
+      AUTHENTICATION_ERROR_CODES = [102, 190, 450, 452, 2500, 104].freeze
 
       # Facebook can return debug information in the response headers -- see
       # https://developers.facebook.com/docs/graph-api/using-graph-api#bugdebug

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -4,7 +4,7 @@ module Koala
   module Facebook
     RSpec.describe GraphErrorChecker do
       it "defines a set of AUTHENTICATION_ERROR_CODES" do
-        expect(GraphErrorChecker::AUTHENTICATION_ERROR_CODES).to match_array([102, 190, 450, 452, 2500])
+        expect(GraphErrorChecker::AUTHENTICATION_ERROR_CODES).to match_array([102, 190, 450, 452, 2500, 104])
       end
 
       it "defines a set of DEBUG_HEADERS" do


### PR DESCRIPTION
Error code 104 represents: `Incorrect signature`, with a type of `OAuthException`

Reference: https://developers.facebook.com/docs/marketing-api/error-reference

These errors come from the Marketing API specifically, and we experience them semi-frequently. It would be nice to catch these as an `AuthenticationError`.

Let me know if this makes sense. Glad to discuss it 😄 