### PR TITLE
Security: Mask input_token in debug_token API call

### DIFF
--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -52,8 +52,10 @@ module Koala
       filtered_args = request.raw_args.dup
 
       if Koala.config.mask_tokens
-        if (token = filtered_args['access_token'])
-          filtered_args['access_token'] = token[0, 10] + '*****' + token[-5, 5]
+        %w(access_token input_token).each do |arg_token|
+          if (token = filtered_args[arg_token])
+            filtered_args[arg_token] = token[0, 10] + '*****' + token[-5, 5]
+          end
         end
       end
 

--- a/lib/koala/http_service.rb
+++ b/lib/koala/http_service.rb
@@ -49,7 +49,7 @@ module Koala
       # set up our Faraday connection
       conn = Faraday.new(request.server, faraday_options(request.options), &(faraday_middleware || DEFAULT_MIDDLEWARE))
 
-      filtered_args = request.raw_args.dup
+      filtered_args = request.raw_args.dup.transform_keys(&:to_s)
 
       if Koala.config.mask_tokens
         %w(access_token input_token).each do |arg_token|

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -257,6 +257,17 @@ describe Koala::HTTPService do
 
         Koala::HTTPService.make_request(request)
       end
+
+      it 'hides the token for the debug_token api endpoint' do
+        request = Koala::HTTPService::Request.new(path: "/debug_token", verb: verb, args: { 'input_token' => 'myvisibleaccesstoken', 'access_token' => 'myvisibleaccesstoken' }, options: options)
+
+        allow(Koala.config).to receive(:mask_tokens) { true }
+
+        expect(Koala::Utils).to receive(:debug).with('STARTED => GET: /debug_token params: {"input_token"=>"myvisiblea*****token", "access_token"=>"myvisiblea*****token"}')
+        expect(Koala::Utils).to receive(:debug).with('FINISHED => GET: /debug_token params: {"input_token"=>"myvisiblea*****token", "access_token"=>"myvisiblea*****token"}')
+
+        Koala::HTTPService.make_request(request)
+      end
     end
   end
 end

--- a/spec/cases/http_service_spec.rb
+++ b/spec/cases/http_service_spec.rb
@@ -259,7 +259,7 @@ describe Koala::HTTPService do
       end
 
       it 'hides the token for the debug_token api endpoint' do
-        request = Koala::HTTPService::Request.new(path: "/debug_token", verb: verb, args: { 'input_token' => 'myvisibleaccesstoken', 'access_token' => 'myvisibleaccesstoken' }, options: options)
+        request = Koala::HTTPService::Request.new(path: "/debug_token", verb: verb, args: { input_token: 'myvisibleaccesstoken', 'access_token' => 'myvisibleaccesstoken' }, options: options)
 
         allow(Koala.config).to receive(:mask_tokens) { true }
 


### PR DESCRIPTION
For review by watchers.

The [debug token](https://developers.facebook.com/docs/graph-api/reference/v8.0/debug_token) API call can leak tokens in the log even with mask_tokens on.
This fix adds input_token to the list of masked tokens.