### PR TITLE
CI: avoid flaps with Koala.configure

### DIFF
--- a/spec/support/koala_test.rb
+++ b/spec/support/koala_test.rb
@@ -51,10 +51,10 @@ module KoalaTest
         @token = KoalaTest.oauth_token
         allow(Koala::Utils).to receive(:deprecate) # never fire deprecation warnings
         # Clean up Koala config
-        Koala.reset_config
       end
 
       config.after :each do
+        Koala.reset_config
         # if we're working with a real user, clean up any objects posted to Facebook
         # no need to do so for test users, since they get deleted at the end
         if @temporary_object_id && KoalaTest.real_user?


### PR DESCRIPTION
Before: we run `Koala.reset_config` in a `before(:each)` to avoid mutation on the global `Koala.configuration` object.

But there are some specs (for example ./spec/cases/test_users_spec.rb:285) which have their own `before(:each)` making calls to the graph api (before the reset) and in some cases it conflicts with the current state of the `Koala.configuration` for example after a test setting a bad configuration on purpose

Proposed fix is to reset the configuration in an `after(:each)` instead