### PR TITLE
Feat/add debug headers for rate limit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ Unreleased
 
 New features:
 
+  * Exposes limiting headers(`x-business-use-case-usage, x-ad-account-usage, x-app-usage`) to APIError ([#668](https://github.com/arsduo/koala/pull/668))
+
 Updated features:
 
 Removed features:
@@ -15,7 +17,7 @@ Testing improvements:
 
 Others:
 
-v3.1.0 (2022-18-01)
+v3.1.0 (2022-01-18)
 ======
 
 New features:

--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -17,7 +17,7 @@ module Koala
 
       # Facebook can return debug information in the response headers -- see
       # https://developers.facebook.com/docs/graph-api/using-graph-api#bugdebug
-      DEBUG_HEADERS = ["x-fb-debug", "x-fb-rev", "x-fb-trace-id", "x-business-use-case-usage", "x-app-usage"]
+      DEBUG_HEADERS = %w[x-fb-debug x-fb-rev x-fb-trace-id x-business-use-case-usage x-ad-account-usage x-app-usage]
 
       def error_if_appropriate
         if http_status >= 400

--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -17,7 +17,7 @@ module Koala
 
       # Facebook can return debug information in the response headers -- see
       # https://developers.facebook.com/docs/graph-api/using-graph-api#bugdebug
-      DEBUG_HEADERS = ["x-fb-debug", "x-fb-rev", "x-fb-trace-id"]
+      DEBUG_HEADERS = ["x-fb-debug", "x-fb-rev", "x-fb-trace-id", "x-business-use-case-usage", "x-app-usage"]
 
       def error_if_appropriate
         if http_status >= 400

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -25,6 +25,7 @@ module Koala
                     :fb_error_debug,
                     :fb_error_rev,
                     :fb_buc_usage,
+                    :fb_ada_usage,
                     :fb_app_usage
 
       # Create a new API Error
@@ -68,8 +69,9 @@ module Koala
           self.fb_error_trace_id = error_info["x-fb-trace-id"]
           self.fb_error_debug = error_info["x-fb-debug"]
           self.fb_error_rev = error_info["x-fb-rev"]
-          self.fb_buc_usage = error_info["x-business-use-case-usage"]
-          self.fb_app_usage = error_info["x-app-usage"]
+          self.fb_buc_usage = json_formatted(error_info["x-business-use-case-usage"])
+          self.fb_ada_usage = json_formatted(error_info["x-ad-account-usage"])
+          self.fb_app_usage = json_formatted(error_info["x-app-usage"])
 
           error_array = []
           %w(type code error_subcode message error_user_title error_user_msg x-fb-trace-id).each do |key|
@@ -85,6 +87,16 @@ module Koala
         message += " [HTTP #{http_status}]" if http_status
 
         super(message)
+      end
+
+      private
+
+      # refs: https://developers.facebook.com/docs/graph-api/overview/rate-limiting/#headers
+      # NOTE: The header will contain a JSON-formatted string that describes current application rate limit usage.
+      def json_formatted(string)
+        JSON.parse(string || '')
+      rescue JSON::ParserError
+        nil
       end
     end
 

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -99,7 +99,7 @@ module Koala
 
         JSON.parse(string)
       rescue JSON::ParserError => e
-        Koala::Utils.logger.error(JSON::ParserError.new("#{e.message}, error_info: #{error_info}"))
+        Koala::Utils.logger.error("#{e.class}: #{e.message} while parsing #{key} = #{string}")
         nil
       end
     end

--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -23,7 +23,9 @@ module Koala
                     :fb_error_user_title,
                     :fb_error_trace_id,
                     :fb_error_debug,
-                    :fb_error_rev
+                    :fb_error_rev,
+                    :fb_buc_usage,
+                    :fb_app_usage
 
       # Create a new API Error
       #
@@ -66,6 +68,8 @@ module Koala
           self.fb_error_trace_id = error_info["x-fb-trace-id"]
           self.fb_error_debug = error_info["x-fb-debug"]
           self.fb_error_rev = error_info["x-fb-rev"]
+          self.fb_buc_usage = error_info["x-business-use-case-usage"]
+          self.fb_app_usage = error_info["x-app-usage"]
 
           error_array = []
           %w(type code error_subcode message error_user_title error_user_msg x-fb-trace-id).each do |key|

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
+BUC_USAGE_JSON = "{\"123456789012345\":[{\"type\":\"messenger\",\"call_count\":1,\"total_cputime\":1,\"total_time\":1,\"estimated_time_to_regain_access\":0}]}"
+ADA_USAGE_JSON = "{\"acc_id_util_pct\":9.67}"
+APP_USAGE_JSON = "{\"call_count\":0,\"total_cputime\":0,\"total_time\":0}"
+
 describe Koala::Facebook::APIError do
   it "is a Koala::KoalaError" do
     expect(Koala::Facebook::APIError.new(nil, nil)).to be_a(Koala::KoalaError)
@@ -33,8 +37,9 @@ describe Koala::Facebook::APIError do
         'x-fb-trace-id' => 'fb trace id',
         'x-fb-debug' => 'fb debug token',
         'x-fb-rev' => 'fb revision',
-        'x-business-use-case-usage' => '{\"123456789012345\":[{\"type\":\"messenger\",\"call_count\":1,\"total_cputime\":1,\"total_time\":1,\"estimated_time_to_regain_access\":0}]}',
-        'x-app-usage' => '{\"call_count\":0,\"total_cputime\":0,\"total_time\":0}'
+        'x-business-use-case-usage' => BUC_USAGE_JSON,
+        'x-ad-account-usage' => ADA_USAGE_JSON,
+        'x-app-usage' => APP_USAGE_JSON
       }
       Koala::Facebook::APIError.new(400, '', error_info)
     }
@@ -49,8 +54,9 @@ describe Koala::Facebook::APIError do
       :fb_error_trace_id => 'fb trace id',
       :fb_error_debug => 'fb debug token',
       :fb_error_rev => 'fb revision',
-      :fb_buc_usage => '{\"123456789012345\":[{\"type\":\"messenger\",\"call_count\":1,\"total_cputime\":1,\"total_time\":1,\"estimated_time_to_regain_access\":0}]}',
-      :fb_app_usage => '{\"call_count\":0,\"total_cputime\":0,\"total_time\":0}'
+      :fb_buc_usage => JSON.parse(BUC_USAGE_JSON),
+      :fb_ada_usage => JSON.parse(ADA_USAGE_JSON),
+      :fb_app_usage => JSON.parse(APP_USAGE_JSON)
     }.each_pair do |accessor, value|
       it "sets #{accessor} to #{value}" do
         expect(error.send(accessor)).to eq(value)
@@ -82,6 +88,7 @@ describe Koala::Facebook::APIError do
         :fb_error_user_msg => 'error user message',
         :fb_error_user_title => 'error user title',
         :fb_buc_usage => nil,
+        :fb_ada_usage => nil,
         :fb_app_usage => nil
       }.each_pair do |accessor, value|
         expect(error.send(accessor)).to eq(value)

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -32,7 +32,9 @@ describe Koala::Facebook::APIError do
         'error_user_title' => 'error user title',
         'x-fb-trace-id' => 'fb trace id',
         'x-fb-debug' => 'fb debug token',
-        'x-fb-rev' => 'fb revision'
+        'x-fb-rev' => 'fb revision',
+        'x-business-use-case-usage' => '{\"123456789012345\":[{\"type\":\"messenger\",\"call_count\":1,\"total_cputime\":1,\"total_time\":1,\"estimated_time_to_regain_access\":0}]}',
+        'x-app-usage' => '{\"call_count\":0,\"total_cputime\":0,\"total_time\":0}'
       }
       Koala::Facebook::APIError.new(400, '', error_info)
     }
@@ -46,7 +48,9 @@ describe Koala::Facebook::APIError do
       :fb_error_user_title => 'error user title',
       :fb_error_trace_id => 'fb trace id',
       :fb_error_debug => 'fb debug token',
-      :fb_error_rev => 'fb revision'
+      :fb_error_rev => 'fb revision',
+      :fb_buc_usage => '{\"123456789012345\":[{\"type\":\"messenger\",\"call_count\":1,\"total_cputime\":1,\"total_time\":1,\"estimated_time_to_regain_access\":0}]}',
+      :fb_app_usage => '{\"call_count\":0,\"total_cputime\":0,\"total_time\":0}'
     }.each_pair do |accessor, value|
       it "sets #{accessor} to #{value}" do
         expect(error.send(accessor)).to eq(value)
@@ -76,7 +80,9 @@ describe Koala::Facebook::APIError do
         :fb_error_code => 1,
         :fb_error_subcode => 'subcode',
         :fb_error_user_msg => 'error user message',
-        :fb_error_user_title => 'error user title'
+        :fb_error_user_title => 'error user title',
+        :fb_buc_usage => nil,
+        :fb_app_usage => nil
       }.each_pair do |accessor, value|
         expect(error.send(accessor)).to eq(value)
       end

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -99,6 +99,15 @@ module Koala
             expect(error.fb_app_usage).to eq({ 'e' => 5, 'f' => 6 })
           end
 
+          it "logs if one of the FB debug headers can't be parsed" do
+            headers.merge!(
+              "x-app-usage" => '{invalid:json}'
+            )
+
+            expect(Koala::Utils.logger).to receive(:error).with("JSON::ParserError: 859: unexpected token at '{invalid:json}' while parsing x-app-usage = {invalid:json}")
+            expect(error.fb_app_usage).to eq(nil)
+          end
+
           context "it returns an AuthenticationError" do
             it "if FB says it's an OAuthException and it has no code" do
               body.replace({"error" => {"type" => "OAuthException"}}.to_json)

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -13,6 +13,7 @@ module Koala
           "x-fb-debug",
           "x-fb-trace-id",
           "x-business-use-case-usage",
+          "x-ad-account-usage",
           "x-app-usage"
         ])
       end
@@ -86,14 +87,16 @@ module Koala
               "x-fb-debug" => double("fb debug"),
               "x-fb-rev" => double("fb rev"),
               "x-fb-trace-id" => double("fb trace id"),
-              "x-business-use-case-usage" => double("fb_buc_usage"),
-              "x-app-usage" => double("fb_app_usage")
+              "x-business-use-case-usage" => { 'a' => 1, 'b' => 2 }.to_json,
+              "x-ad-account-usage" => { 'c' => 3, 'd' => 4 }.to_json,
+              "x-app-usage" => { 'e' => 5, 'f' => 6 }.to_json
             )
             expect(error.fb_error_trace_id).to eq(headers["x-fb-trace-id"])
             expect(error.fb_error_debug).to eq(headers["x-fb-debug"])
             expect(error.fb_error_rev).to eq(headers["x-fb-rev"])
-            expect(error.fb_buc_usage).to eq(headers["x-business-use-case-usage"])
-            expect(error.fb_app_usage).to eq(headers["x-app-usage"])
+            expect(error.fb_buc_usage).to eq({ 'a' => 1, 'b' => 2 })
+            expect(error.fb_ada_usage).to eq({ 'c' => 3, 'd' => 4 })
+            expect(error.fb_app_usage).to eq({ 'e' => 5, 'f' => 6 })
           end
 
           context "it returns an AuthenticationError" do

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -11,7 +11,9 @@ module Koala
         expect(GraphErrorChecker::DEBUG_HEADERS).to match_array([
           "x-fb-rev",
           "x-fb-debug",
-          "x-fb-trace-id"
+          "x-fb-trace-id",
+          "x-business-use-case-usage",
+          "x-app-usage"
         ])
       end
 
@@ -84,10 +86,14 @@ module Koala
               "x-fb-debug" => double("fb debug"),
               "x-fb-rev" => double("fb rev"),
               "x-fb-trace-id" => double("fb trace id"),
+              "x-business-use-case-usage" => double("fb_buc_usage"),
+              "x-app-usage" => double("fb_app_usage")
             )
             expect(error.fb_error_trace_id).to eq(headers["x-fb-trace-id"])
             expect(error.fb_error_debug).to eq(headers["x-fb-debug"])
             expect(error.fb_error_rev).to eq(headers["x-fb-rev"])
+            expect(error.fb_buc_usage).to eq(headers["x-business-use-case-usage"])
+            expect(error.fb_app_usage).to eq(headers["x-app-usage"])
           end
 
           context "it returns an AuthenticationError" do


### PR DESCRIPTION
base on #635

we should expose the rate-limit-related info when got an API error.

my use case 

```ruby
fb_graph = Koala::Facebook::API.new('PAGE_TOKEN', false)
begin
  response = fb_graph.get_connections('POST_ID', nil, http_component: :response)
  # <Koala::Facebook::ClientError: type: OAuthException, code: 80001, message: (#80001) There have been too many calls to this Page account.
  response.headers['x-business-use-case-usage']
rescue Koala::Facebook::APIError => e
  e.fb_buc_usage
  # => "{\"PAGE_ID\":[{\"type\":\"pages\",\"call_count\":107,\"total_cputime\":1,\"total_time\":125,\"estimated_time_to_regain_access\":1310}]}"
end

```



--- 

- [x] My PR has tests and they pass!
- [x] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
- [x] The PR is based on the most recent master commit and has no merge conflicts.
