### PR TITLE
Fix: builds for ruby 3+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "rspec", '~> 3.4'
+  gem "rspec", "~> 3.0", "< 3.10" # resrict rspec version until https://github.com/rspec/rspec-support/pull/537 gets merged
   gem "vcr", github: 'vcr/vcr', ref: '8ced6c96e01737a418cd270e0382a8c2c6d85f7f' # needs https://github.com/vcr/vcr/pull/907 for ruby 3.1
   gem "webmock"
   gem "simplecov"

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ Internal improvements:
 
 Testing improvements:
 
+* Fix builds for ruby 3.x
+
 Others:
 
 v3.1.0 (2022-18-01)


### PR DESCRIPTION
Current builds for ruby 3+ are failing because of this error:

```
Failures:

  1) Koala::Facebook::GraphAPIMethods #graph_call the appsecret_proof option is enabled by default if an app secret is present
     Failure/Error: response = api(path, args, verb, options)

       #<Koala::Facebook::API:0x000056012ae8[25](https://github.com/arsduo/koala/runs/6555738033?check_suite_focus=true#step:5:26)c0 @access_token="*", @app_secret="mysecret"> received :api with unexpected arguments
         expected: ("/path", {}, "get", {:appsecret_proof=>true})
              got: ("/path", {}, "get", {:appsecret_proof=>true})
     # ./lib/koala/api.rb:47:in `graph_call'
     # ./spec/cases/graph_api_spec.rb:61:in `block (4 levels) in <top (required)>'
```

As far as I know this is linked to latest rspec updates and we need https://github.com/rspec/rspec-support/pull/537 to be merged and released before we can use latest versions of rspec

For the moment I'm locking the rspec version to the latest one which was working flawlessly