### PR TITLE
Hook to handle rate limits from response headers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Unreleased
 New features:
 
   * Exposes limiting headers(`x-business-use-case-usage, x-ad-account-usage, x-app-usage`) to APIError ([#668](https://github.com/arsduo/koala/pull/668))
+  * Add `rate_limit_hook` configuration to get rate limiting headers (`x-business-use-case-usage, x-ad-account-usage, x-app-usage`) ([#670](https://github.com/arsduo/koala/pull/670))
 
 Updated features:
 

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -13,7 +13,7 @@ module Koala
       #                 signed by default, unless you pass appsecret_proof:
       #                 false as an option to the API call. (See
       #                 https://developers.facebook.com/docs/graph-api/securing-requests/)
-      # @param [Block]  rate_limit_hook block called with limit received in facebook response headers
+      # @param [Block]  rate_limit_hook block called with limits received in facebook response headers
       # @note If no access token is provided, you can only access some public information.
       # @return [Koala::Facebook::API] the API client
       def initialize(access_token = Koala.config.access_token, app_secret = Koala.config.app_secret, rate_limit_hook = Koala.config.rate_limit_hook)

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -66,10 +66,10 @@ module Koala
             next unless value
             hash[key] = JSON.parse(response.headers[key])
           rescue JSON::ParserError => e
-            Koala::Utils.logger.error("#{e.class}: #{e.message} while parsing #{key} = #{string}")
+            Koala::Utils.logger.error("#{e.class}: #{e.message} while parsing #{key} = #{value}")
           end
 
-          rate_limit_hook.call(limits)
+          rate_limit_hook.call(limits) if limits.keys.any?
         end
 
         # now process as appropriate for the given call (get picture header, etc.)

--- a/lib/koala/api.rb
+++ b/lib/koala/api.rb
@@ -13,14 +13,16 @@ module Koala
       #                 signed by default, unless you pass appsecret_proof:
       #                 false as an option to the API call. (See
       #                 https://developers.facebook.com/docs/graph-api/securing-requests/)
+      # @param [Block]  rate_limit_hook block called with limit received in facebook response headers
       # @note If no access token is provided, you can only access some public information.
       # @return [Koala::Facebook::API] the API client
-      def initialize(access_token = Koala.config.access_token, app_secret = Koala.config.app_secret)
+      def initialize(access_token = Koala.config.access_token, app_secret = Koala.config.app_secret, rate_limit_hook = Koala.config.rate_limit_hook)
         @access_token = access_token
         @app_secret = app_secret
+        @rate_limit_hook = rate_limit_hook
       end
 
-      attr_reader :access_token, :app_secret
+      attr_reader :access_token, :app_secret, :rate_limit_hook
 
       include GraphAPIMethods
 
@@ -58,15 +60,17 @@ module Koala
           API::GraphCollection.evaluate(response, self)
         end
 
-        limits = %w(x-business-use-case-usage x-ad-account-usage x-app-usage).each_with_object({}) do |key, hash|
-          value = response.headers.fetch(key, nil)
-          next unless value
-          hash[key] = JSON.parse(response.headers[key])
-        rescue JSON::ParserError => e
-          Koala::Utils.logger.error("#{e.class}: #{e.message} while parsing #{key} = #{string}")
-        end
+        if rate_limit_hook
+          limits = %w(x-business-use-case-usage x-ad-account-usage x-app-usage).each_with_object({}) do |key, hash|
+            value = response.headers.fetch(key, nil)
+            next unless value
+            hash[key] = JSON.parse(response.headers[key])
+          rescue JSON::ParserError => e
+            Koala::Utils.logger.error("#{e.class}: #{e.message} while parsing #{key} = #{string}")
+          end
 
-        Koala.config.rate_limit_hook&.call(limits)
+          rate_limit_hook.call(limits)
+        end
 
         # now process as appropriate for the given call (get picture header, etc.)
         post_processing ? post_processing.call(desired_data) : desired_data

--- a/lib/koala/configuration.rb
+++ b/lib/koala/configuration.rb
@@ -31,6 +31,9 @@ class Koala::Configuration
   # Whether or not to mask tokens
   attr_accessor :mask_tokens
 
+  # Called with the info for the rate limits in the response header
+  attr_accessor :rate_limit_hook
+
   # Certain Facebook services (beta, video) require you to access different
   # servers. If you're using your own servers, for instance, for a proxy,
   # you can change both the matcher (what value to change when updating the URL) and the

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,37 @@ Koala::Facebook::RealtimeUpdates.meet_challenge(params, your_verify_token)
 ```
 For more information about meet_challenge and the RealtimeUpdates class, check out the Real-Time Updates page on the wiki.
 
+Rate limits
+-----------
+
+We support Facebook rate limit informations as defined here: [https://developers.facebook.com/docs/graph-api/overview/rate-limiting/](https://developers.facebook.com/docs/graph-api/overview/rate-limiting/)
+
+The information is available either via the `Facebook::APIError`:
+
+```
+error.fb_buc_usage
+error.fb_ada_usage
+error.fb_app_usage
+```
+
+Or with the rate_limit_hook:
+
+```
+# App level configuration
+
+Koala.configure do |config|
+  config.rate_limit_hook = ->(limits) { 
+    limits["x-app-usage"] # {"call_count"=>0, "total_cputime"=>0, "total_time"=>0}
+    limits["x-ad-account-usage"] # {"acc_id_util_pct"=>9.67}
+    limits["x-business-use-case-usage"] # {"123456789012345"=>[{"type"=>"messenger", "call_count"=>1, "total_cputime"=>1, "total_time"=>1, "estimated_time_to_regain_access"=>0}]}
+  }
+end
+
+# Per API configuration
+
+Koala::Facebook::API.new('', '', ->(limits) {})
+```
+
 Test Users
 ----------
 

--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,7 @@ We support Facebook rate limit informations as defined here: [https://developers
 
 The information is available either via the `Facebook::APIError`:
 
-```
+```ruby
 error.fb_buc_usage
 error.fb_ada_usage
 error.fb_app_usage
@@ -192,7 +192,7 @@ error.fb_app_usage
 
 Or with the rate_limit_hook:
 
-```
+```ruby
 # App level configuration
 
 Koala.configure do |config|

--- a/spec/cases/graph_api_batch_spec.rb
+++ b/spec/cases/graph_api_batch_spec.rb
@@ -593,7 +593,7 @@ describe "Koala::Facebook::GraphAPI in batch mode" do
           hash_including(@other_access_token_args.dup),
           anything,
           anything
-      ).and_return(Koala::HTTPService::Response.new(200, "", ""))
+      ).and_return(Koala::HTTPService::Response.new(200, "", {}))
 
       # Page the collection
       app_event_types.next_page


### PR DESCRIPTION
Thanks for submitting a pull request to Koala! A huge portion of the gem has been built by awesome people (like you) from the Ruby community.

Here are a few things that will help get your pull request merged in quickly. None of this is required -- you can delete anything not relevant. If in doubt, open the PR! I want to help.

- [x] My PR has tests and they pass!
- [x] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
- [x] The PR is based on the most recent master commit and has no merge conflicts.

If you have any questions, feel free to open an issue or comment on your PR!

Note: Koala has a [code of conduct](https://github.com/arsduo/koala/blob/master/code_of_conduct.md). Check it out.



The idea is to have a hook to handle the rate limit info that facebook returns in the response headers.
There is a global hook configuration and it can be overriden per a `Koala::Facebook::API` basis.

Example:

```ruby
Koala.config.rate_limit_hook = ->(limits) do
  Rails.logger.warn("FB: #{limits.inspect}")
end

@insta_client ||= Koala::Facebook::API.new(insta_token, secret, ->(limits) {
    Rails.logger.warn("Insta: #{limits.inspect}")
})

=> May 23 19:54:12 app WARN: FB: {"x-app-usage"=>{"call_count"=>9, "total_cputime"=>0, "total_time"=>1}}
=> May 23 20:00:32 app WARN: Insta: {"x-business-use-case-usage"=>{"fbid"=>[{"type"=>"instagram", "call_count"=>2, "total_cputime"=>1, "total_time"=>1, "estimated_time_to_regain_access"=>0}]}}
```

closing #635 