### PR TITLE
Fix tests with ruby head

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ Internal improvements:
 
 Testing improvements:
 
+ * Fix tests with ruby-head ([#674](https://github.com/arsduo/koala/pull/674))
+
 Others:
 
 v3.2.0 (2022-05-27)

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -345,7 +345,7 @@ describe "Koala::Facebook::API" do
       response = Koala::HTTPService::Response.new(200, result.to_json, { "x-ad-account-usage" => "{\"acc_id_util_pct\"9.67}"})
       allow(Koala).to receive(:make_request).and_return(response)
 
-      expect(Koala::Utils.logger).to receive(:error).with("JSON::ParserError: 859: unexpected token at '{\"acc_id_util_pct\"9.67}' while parsing x-ad-account-usage = {\"acc_id_util_pct\"9.67}")
+      expect(Koala::Utils.logger).to receive(:error).with(/JSON::ParserError:.*unexpected token at '{"acc_id_util_pct"9.67}' while parsing x-ad-account-usage = {"acc_id_util_pct"9.67}/)
       api.graph_call('anything')
     end
 

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -104,7 +104,7 @@ module Koala
               "x-app-usage" => '{invalid:json}'
             )
 
-            expect(Koala::Utils.logger).to receive(:error).with("JSON::ParserError: 859: unexpected token at '{invalid:json}' while parsing x-app-usage = {invalid:json}")
+            expect(Koala::Utils.logger).to receive(:error).with(/JSON::ParserError:.*unexpected token at '{invalid:json}' while parsing x-app-usage = {invalid:json}/)
             expect(error.fb_app_usage).to eq(nil)
           end
 


### PR DESCRIPTION
With ruby-head we have the following errors:

```
Failures:

  1) Koala::Facebook::API Rate limit hook isn't called if no rate limit hook is defined
     Failure/Error: Koala::Utils.logger.error("#{e.class}: #{e.message} while parsing #{key} = #{value}")

       #<Logger:0x00007fe5def9d0a0 @level=3, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007fe5def9cf60 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x00007fe5def9cda8 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x00007fe5def9cce0>, @mon_data_owner_object_id=3060>> received :error with unexpected arguments
         expected: ("JSON::ParserError: 859: unexpected token at '{\"acc_id_util_pct\"9.67}' while parsing x-ad-account-usage = {\"acc_id_util_pct\"9.67}")
              got: ("JSON::ParserError: unexpected token at '{\"acc_id_util_pct\"9.67}' while parsing x-ad-account-usage = {\"acc_id_util_pct\"9.67}")
     # ./lib/koala/api.rb:69:in `rescue in block in graph_call'
     # ./lib/koala/api.rb:65:in `block in graph_call'
     # ./lib/koala/api.rb:64:in `each'
     # ./lib/koala/api.rb:64:in `each_with_object'
     # ./lib/koala/api.rb:64:in `graph_call'
     # ./spec/cases/api_spec.rb:349:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # JSON::ParserError:
     #   unexpected token at '{"acc_id_util_pct"9.67}'
     #   ./lib/koala/api.rb:67:in `block in graph_call'

  2) Koala::Facebook::GraphErrorChecker#error_if_appropriate if the status is 4xx it should behave like returns_an_error logs if one of the FB debug headers can't be parsed
     Failure/Error: Koala::Utils.logger.error("#{e.class}: #{e.message} while parsing #{key} = #{string}")

       #<Logger:0x00007fe5def9d0a0 @level=3, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007fe5def9cf60 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x00007fe5def9cda8 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x00007fe5def9cce0>, @mon_data_owner_object_id=3060>> received :error with unexpected arguments
         expected: ("JSON::ParserError: 859: unexpected token at '{invalid:json}' while parsing x-app-usage = {invalid:json}")
              got: ("JSON::ParserError: unexpected token at '{invalid:json}' while parsing x-app-usage = {invalid:json}")
     Shared Example Group: :returns_an_error called from ./spec/cases/graph_error_checker_spec.rb:134
     # ./lib/koala/errors.rb:102:in `rescue in json_parse_for'
     # ./lib/koala/errors.rb:96:in `json_parse_for'
     # ./lib/koala/errors.rb:74:in `initialize'
     # ./lib/koala/api/graph_error_checker.rb:24:in `new'
     # ./lib/koala/api/graph_error_checker.rb:24:in `error_if_appropriate'
     # ./spec/cases/graph_error_checker_spec.rb:48:in `block (4 levels) in <module:Facebook>'
     # ./spec/cases/graph_error_checker_spec.rb:108:in `block (4 levels) in <module:Facebook>'
     # ------------------
     # --- Caused by: ---
     # JSON::ParserError:
     #   unexpected token at '{invalid:json}'
     #   ./lib/koala/errors.rb:100:in `json_parse_for'

Finished in 0.96526 seconds (files took 0.62811 seconds to load)
627 examples, 2 failures, 1 pending

Failed examples:

rspec ./spec/cases/api_spec.rb:339 # Koala::Facebook::API Rate limit hook isn't called if no rate limit hook is defined
rspec ./spec/cases/graph_error_checker_spec.rb:102 # Koala::Facebook::GraphErrorChecker#error_if_appropriate if the status is 4xx it should behave like returns_an_error logs if one of the FB debug headers can't be parsed
```