### PR TITLE
Keep supported rubies for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", 3.1, head]
+        ruby: [2.7, "3.0", 3.1, head]
 
     steps:
     - name: Checkout repository

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Internal improvements:
 Testing improvements:
 
  * Fix tests with ruby-head ([#674](https://github.com/arsduo/koala/pull/674))
+ * Keep supported rubies (non EOL) for CI ([#675](https://github.com/arsduo/koala/pull/675))
 
 Others:
 


### PR DESCRIPTION
In https://github.com/arsduo/koala/pull/666 I'm adding fraday-typhoeus adapter which requires ruby >= 2.7 so lets change the CI to support only >= 2.7 (not changing the required ruby version for the gem itself until we get a real need)