### PR TITLE
Use HTTPS by default even when there's no access token

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ New features:
 
 Updated features:
 
+* Force use by default of HTTPS (instead of HTTP) when there is no access token
+  HTTP can still be used by passing :use_ssl => false in the options hash for an api call
+
 Removed features:
 
 Internal improvements:

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ New features:
 
 Updated features:
 
-* Force use by default of HTTPS (instead of HTTP) when there is no access token
+* Force use by default of HTTPS (instead of HTTP) when there is no access token.
   HTTP can still be used by passing :use_ssl => false in the options hash for an api call ([#678](https://github.com/arsduo/koala/pull/678/files))
 
 Removed features:

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ New features:
 Updated features:
 
 * Force use by default of HTTPS (instead of HTTP) when there is no access token
-  HTTP can still be used by passing :use_ssl => false in the options hash for an api call
+  HTTP can still be used by passing :use_ssl => false in the options hash for an api call ([#678](https://github.com/arsduo/koala/pull/678/files))
 
 Removed features:
 

--- a/lib/koala/http_service/request.rb
+++ b/lib/koala/http_service/request.rb
@@ -106,7 +106,7 @@ module Koala
       end
 
       def add_ssl_options(opts)
-        # always require https
+        # require https by default (can be overriden by explicitly setting other SSL options)
         {
           use_ssl: true,
           ssl: {verify: true}.merge(opts[:ssl] || {})

--- a/lib/koala/http_service/request.rb
+++ b/lib/koala/http_service/request.rb
@@ -106,9 +106,7 @@ module Koala
       end
 
       def add_ssl_options(opts)
-        # require https if there's a token
-        return opts unless raw_args["access_token"]
-
+        # always require https
         {
           use_ssl: true,
           ssl: {verify: true}.merge(opts[:ssl] || {})

--- a/spec/cases/http_service/request_spec.rb
+++ b/spec/cases/http_service/request_spec.rb
@@ -176,9 +176,9 @@ module Koala
         end
 
         describe "ssl options" do
-          it "does nothing if there's no access token" do
+          it "includes the default SSL options even if there's no access token" do
             request_options = Request.new(path: path, args: args.delete_if {|k, _v| k == "access_token"}, verb: verb, options: options).options
-            expect(request_options).not_to include(:ssl, :use_ssl)
+            expect(request_options).to include(use_ssl: true, ssl: {verify: true})
           end
 
           context "if there is an access_token" do
@@ -193,9 +193,9 @@ module Koala
             end
 
             it "overrides default SSL options with what's provided" do
-              new_ssl_options = {verify: :dunno}
-              request_options = Request.new(path: path, args: args, verb: verb, options: options.merge(ssl: new_ssl_options)).options
-              expect(request_options[:ssl]).to include(new_ssl_options)
+              new_ssl_options = {use_ssl: false, ssl:{verify: :dunno}}
+              request_options = Request.new(path: path, args: args, verb: verb, options: options.merge(new_ssl_options)).options
+              expect(request_options).to include(new_ssl_options)
             end
           end
         end
@@ -211,8 +211,16 @@ module Koala
               expect(request.server).to eq("https://foo")
             end
 
-            context "if options[:use_ssl] is false (e.g. no access token)" do
+            context "if there is no access token" do
               let(:args) { {"a" => "b"} }
+
+              it "uses https" do
+                expect(request.server).to eq("https://graph.facebook.com")
+              end
+            end
+
+            context "if options[:use_ssl] is false" do
+              let(:options) { {use_ssl: false} }
 
               it "uses http" do
                 expect(request.server).to eq("http://graph.facebook.com")


### PR DESCRIPTION
Recently we've been having errors while using Koala because facebook doesn't raise its usual error when making a call without access token, see:

```
curl -i -X GET "http://graph.facebook.com/v15.0/me/accounts"

HTTP/1.1 301 Moved Permanently
Location: https://graph.facebook.com/v15.0/me/accounts
Content-Type: text/plain
Server: proxygen-bolt
Date: Wed, 16 Nov 2022 09:01:48 GMT
Connection: keep-alive
Content-Length: 0
```

This happens only when using HTTP and it breaks our all flow
With HTTPS the error is raised normally, see:

```
curl -i -X GET "https://graph.facebook.com/v15.0/me/accounts"

HTTP/2 400 
vary: Origin
access-control-allow-origin: *
x-fb-rlafr: 0
content-type: application/json; charset=UTF-8
www-authenticate: OAuth "Facebook Platform" "invalid_request" "An active access token must be used to query information about the current user."
facebook-api-version: v15.0
strict-transport-security: max-age=15552000; preload
pragma: no-cache
cache-control: no-store
expires: Sat, 01 Jan 2000 00:00:00 GMT
x-fb-request-id: A_3mWAWs3D9ZKXx-RMTMjej
x-fb-trace-id: FhdgMx6Khet
x-fb-rev: 1006788601
x-fb-debug: v7SD14KLX7bN2uUnUfF6Mdfn46MoK6itoETzI3rbPbX3k0a0N8o8k45EHiKSdkR7Yvyt62WysmnWIpjfKoAxTA==
content-length: 179
date: Thu, 05 Jan 2023 10:18:33 GMT
priority: u=3,i
alt-svc: h3=":443"; ma=86400

{"error":{"message":"An active access token must be used to query information about the current user.","type":"OAuthException","code":2500,"fbtrace_id":"A_3mWAWs3D9ZKXx-RMTMjej"}}
```

I tried to get more info from fb but they were not really helpful and said nothing changed on their side https://developers.facebook.com/support/bugs/463153232612314/
So the goal here is to make koala use https by default even when there's no access token
This can still be overridden by explicitly setting the ssl options in the koala call