### PR TITLE
Expand AuthenticationError codes

### DIFF
--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -13,7 +13,7 @@ module Koala
 
       # Facebook has a set of standardized error codes, some of which represent problems with the
       # token.
-      AUTHENTICATION_ERROR_CODES = [102, 190, 450, 452, 2500]
+      AUTHENTICATION_ERROR_CODES = [100, 102, 190, 200, 450, 452, 2500]
 
       # Facebook can return debug information in the response headers -- see
       # https://developers.facebook.com/docs/graph-api/using-graph-api#bugdebug

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -4,7 +4,7 @@ module Koala
   module Facebook
     RSpec.describe GraphErrorChecker do
       it "defines a set of AUTHENTICATION_ERROR_CODES" do
-        expect(GraphErrorChecker::AUTHENTICATION_ERROR_CODES).to match_array([102, 190, 450, 452, 2500])
+        expect(GraphErrorChecker::AUTHENTICATION_ERROR_CODES).to match_array([100, 102, 190, 200, 450, 452, 2500])
       end
 
       it "defines a set of DEBUG_HEADERS" do


### PR DESCRIPTION
Add two more error codes to `AuthenticationError`
1. type: OAuthException, code: 100, message: (#100) Missing permissions, x-fb-trace-id: <redacted> [HTTP 400]
2. type: OAuthException, code: 200, message: (#200) The current user can not update audience <redacted>, x-fb-trace-id: <redacted> [HTTP 403]

Thanks for submitting a pull request to Koala! A huge portion of the gem has been built by awesome people (like you) from the Ruby community.

Here are a few things that will help get your pull request merged in quickly. None of this is required -- you can delete anything not relevant. If in doubt, open the PR! I want to help.

[x] My PR has tests and they pass!
[x] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
[x] The PR is based on the most recent master commit and has no merge conflicts.

If you have any questions, feel free to open an issue or comment on your PR!

Note: Koala has a [code of conduct](https://github.com/arsduo/koala/blob/master/code_of_conduct.md). Check it out.