### PR TITLE
Fix: Return ClientError instead of NoMethodError when body is 'null'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Updated features:
 Removed features:
 
 Internal improvements:
+* Raise ClientError instead of NoMethodError when body is 'null' ([#673](https://github.com/arsduo/koala/issues/673))
 
 Testing improvements:
 

--- a/lib/koala/api/graph_error_checker.rb
+++ b/lib/koala/api/graph_error_checker.rb
@@ -61,7 +61,8 @@ module Koala
         # Normally, we start with the response body. If it isn't valid JSON, we start with an empty
         # hash and fill it with error data.
         @response_hash ||= begin
-          JSON.parse(body)
+          parsed_body = JSON.parse(body)
+          parsed_body.is_a?(Hash) ? parsed_body : {}
         rescue JSON::ParserError
           {}
         end

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -63,6 +63,12 @@ module Koala
             expect(error.response_body).to eq(body)
           end
 
+          it "returns a ClientError if the body is null" do
+            body.replace("null")
+            expect(error).to be_a(ClientError)
+            expect(error.response_body).to eq(body)
+          end
+
           it "adds error data from the body" do
             error_data = {
               "type" => "FB error type",


### PR DESCRIPTION
Fix for #673 