### PR TITLE
Add PermissionError

### DIFF
--- a/lib/koala/errors.rb
+++ b/lib/koala/errors.rb
@@ -119,6 +119,8 @@ module Koala
     # All graph API authentication failures.
     class AuthenticationError < ClientError; end
 
+    # API requests failing due to missing permission
+    class PermissionError < ClientError; end
   end
 
 end

--- a/spec/cases/error_spec.rb
+++ b/spec/cases/error_spec.rb
@@ -139,3 +139,9 @@ describe Koala::Facebook::AuthenticationError do
      expect(Koala::Facebook::AuthenticationError.new(nil, nil)).to be_a(Koala::Facebook::ClientError)
   end
 end
+
+describe Koala::Facebook::PermissionError do
+  it "is a Koala::Facebook::ClientError" do
+     expect(Koala::Facebook::PermissionError.new(nil, nil)).to be_a(Koala::Facebook::ClientError)
+  end
+end

--- a/spec/cases/graph_error_checker_spec.rb
+++ b/spec/cases/graph_error_checker_spec.rb
@@ -122,9 +122,26 @@ module Koala
             end
           end
 
-          # Note: I'm not sure why this behavior was implemented, it may be incorrect. To
-          # investigate.
           it "doesn't return an AuthenticationError if FB says it's an OAuthException but the code doesn't match" do
+            body.replace({"error" => {"type" => "OAuthException", "code" => 2499}}.to_json)
+            expect(error).to be_an(ClientError)
+          end
+
+          context "it returns a PermissionError" do
+            GraphErrorChecker::PERMISSION_ERROR_CODES.each do |error_code|
+              it "if FB says it's an OAuthException and it has code #{error_code} and no subcode" do
+                body.replace({"error" => {"type" => "OAuthException", "code" => error_code}}.to_json)
+                expect(error).to be_an(PermissionError)
+              end
+            end
+          end
+
+          it "doesn't return a PermissionError if FB says it's an OAuthException but error_subcode is present" do
+            body.replace({"error" => {"type" => "OAuthException", "code" => 100, "error_subcode" => 33}}.to_json)
+            expect(error).to be_an(ClientError)
+          end
+
+          it "doesn't return a PermissionError if FB says it's an OAuthException but the code doesn't match" do
             body.replace({"error" => {"type" => "OAuthException", "code" => 2499}}.to_json)
             expect(error).to be_an(ClientError)
           end


### PR DESCRIPTION
Add `PermissionError` as per https://github.com/arsduo/koala/pull/680#issuecomment-1676931091
1. `type: OAuthException, code: 100, message: (#100) Missing permissions, x-fb-trace-id: <redacted> [HTTP 400]`
2. `type: OAuthException, code: 200, message: (#200) The current user can not update audience <redacted>, x-fb-trace-id: <redacted> [HTTP 403]`

Thanks for submitting a pull request to Koala! A huge portion of the gem has been built by awesome people (like you) from the Ruby community.

Here are a few things that will help get your pull request merged in quickly. None of this is required -- you can delete anything not relevant. If in doubt, open the PR! I want to help.

[x] My PR has tests and they pass!
[x] The live tests pass for my changes (`LIVE=true rspec` -- unrelated failures are okay).
[x] The PR is based on the most recent master commit and has no merge conflicts.

If you have any questions, feel free to open an issue or comment on your PR!

Note: Koala has a [code of conduct](https://github.com/arsduo/koala/blob/master/code_of_conduct.md). Check it out.