### PR TITLE
Better: require base64 for ruby 3.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, "3.0", 3.1, head]
+        ruby: [2.7, "3.0", 3.1, 3.2, 3.3, head]
 
     steps:
     - name: Checkout repository

--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,11 @@ Removed features:
 
 Internal improvements:
 
+* Require base64 for ruby 3.4 support ([#688](https://github.com/arsduo/koala/pull/688))
+
 Testing improvements:
 
+* Fix CI for ruby 3.4 ([#688](https://github.com/arsduo/koala/pull/688))
 * Add latest rubies to CI ([#687](https://github.com/arsduo/koala/pull/687))
 
 Others:

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ Internal improvements:
 
 Testing improvements:
 
+* Add latest rubies to CI ([#687](https://github.com/arsduo/koala/pull/687))
+
 Others:
 
 v3.5.0 (2023-08-23)

--- a/koala.gemspec
+++ b/koala.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("addressable")
   gem.add_runtime_dependency("json", ">= 1.8")
   gem.add_runtime_dependency("rexml")
+  gem.add_runtime_dependency("base64")
 end


### PR DESCRIPTION
Add base64 dependency for ruby 3.4 support