### PR TITLE
Bump GHA action plugins to avoid deprecation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       run: bundle install --jobs 4 --retry 3
 
     - name: Specs & Coverage
-      uses: paambaati/codeclimate-action@v3.0.0
+      uses: paambaati/codeclimate-action@v6
       env:
         CC_TEST_REPORTER_ID: 7af99d9225b4c14640f9ec3cb2e24d2f7103ac49417b0bd989188fb6c25f2909
       with:

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Testing improvements:
 
 * Fix CI for ruby 3.4 ([#688](https://github.com/arsduo/koala/pull/688))
 * Add latest rubies to CI ([#687](https://github.com/arsduo/koala/pull/687))
+* Bump GHA action plugins to avoid deprecation warnings ([#689](https://github.com/arsduo/koala/pull/689))
 
 Others:
 


### PR DESCRIPTION
simple bump, removes old node warnings