### PR TITLE
Fix Ruby 3.3.5 ostruct warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ Removed features:
 
 Internal improvements:
 
+ * explicitly require ostruct for ruby >= 3.3.5 ([694](https://github.com/arsduo/koala/pull/694))
+
 Testing improvements:
 
 Others:

--- a/koala.gemspec
+++ b/koala.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("json", ">= 1.8")
   gem.add_runtime_dependency("rexml")
   gem.add_runtime_dependency("base64")
+  gem.add_runtime_dependency("ostruct")
 end


### PR DESCRIPTION
The following warning is thrown with Ruby 3.3.5:
```
ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of koala-3.6.0 to request adding ostruct into its gemspec.
```

- [x] The PR is based on the most recent master commit and has no merge conflicts.